### PR TITLE
Performance dies as you page through results

### DIFF
--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -421,7 +421,9 @@ class SearchBackend(BaseSearchBackend):
             'queries': {},
         }
         
-        if not end_offset:
+        if end_offset:
+            end_offset = end_offset - start_offset
+        else:
             end_offset = database.get_doccount() - start_offset
         
         matches = self._get_enquire_mset(database, enquire, start_offset, end_offset)


### PR DESCRIPTION
I noticed that memory usage and computation time were exploding the further I paged through a paginated view of some documents. After poking around, it seems that haystack calls the search method with an end_offset that equals the absolute index of the last record whereas xapian wants an quantity relative to the start_offset (i.e. number of docs to return). So, if I wanted page 100 with 50 items per page it was actually returning 5000 results.

There's a module-level 'run' method in xapian-backend that seems to understand this, but I don't see how it was supposed to meet up with haystack. Maybe someone with a better understanding of what's going on there will have a more appropriate fix.
