### PR TITLE
Query with special chars throws sre_constants.error exception

### DIFF
--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -644,7 +644,7 @@ class XapianSearchBackend(BaseSearchBackend):
         """
         for term in query:
             for match in re.findall('[^A-Z]+', term):  # Ignore field identifiers
-                match_re = re.compile(match, re.I)
+                match_re = re.compile(re.escape(match), re.I)
                 content = match_re.sub('<%s>%s</%s>' % (tag, term, tag), content)
 
         return content


### PR DESCRIPTION
Queries like "C++" are not working:

<pre>
  File "/home/mirec/.virtualenvs/django/lib/python2.7/site-packages/xapian_backend.py", line 647, in _do_highlight
    match_re = re.compile(match, re.I)
  File "/usr/lib64/python2.7/re.py", line 190, in compile
    return _compile(pattern, flags)
  File "/usr/lib64/python2.7/re.py", line 242, in _compile
    raise error, v # invalid expression
error: multiple repeat
</pre>

