### PR TITLE
error syntax on list FIELD_TYPES

### DIFF
--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -61,7 +61,7 @@ XAPIAN_OPTS = {'AND': xapian.Query.OP_AND,
 DEFAULT_CHECK_AT_LEAST = 1000
 
 # field types accepted to be serialized as values in Xapian
-FIELD_TYPES = {'text', 'integer', 'date', 'datetime', 'float', 'boolean'}
+FIELD_TYPES = ('text', 'integer', 'date', 'datetime', 'float', 'boolean')
 
 # defines the format used to store types in Xapian
 # this format ensures datetimes are sorted correctly


### PR DESCRIPTION
I've got this error when I try to migrate:

[127.0.0.1] out:     **import**(name)
[127.0.0.1] out:   File "/usr/lib/python2.6/site-packages/xapian_backend.py", line 64
[127.0.0.1] out:     FIELD_TYPES = {'text', 'integer', 'date', 'datetime', 'float', 'boolean'}
[127.0.0.1] out:                          ^
[127.0.0.1] out: SyntaxError: invalid syntax
