### PR TITLE
Added Python 3.3 to .travis.yml and updated installation procedure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - git clone https://github.com/toastdriven/django-haystack.git
   - sudo apt-get install uuid-dev
   # install Xapian 1.2.19
-  - curl https://gist.githubusercontent.com/jorgecarleitao/45c312987f0d0e0f843d/raw/d27dbae4fb2a293bbba5067038399f204bb8b6e7 | bash -s 1.2.19
+  - curl https://gist.githubusercontent.com/jorgecarleitao/45c312987f0d0e0f843d/raw/d27dbae4fb2a293bbba5067038399f204bb8b6e7 | sudo bash -s 1.2.19
 
 # move xapian-haystack to django-haystack
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.3"
 
 env:
   - DJANGO_VERSION=1.6.11
@@ -12,8 +13,9 @@ install:
   - pip install -q Django==$DJANGO_VERSION --use-mirrors
   - cd ..
   - git clone https://github.com/toastdriven/django-haystack.git
-  - sudo apt-get install -qq libxapian22 xapian-tools python-xapian
-  - ln -s /usr/lib/python2.7/dist-packages/xapian $VIRTUAL_ENV/lib/python2.7/site-packages/.
+  - sudo apt-get install uuid-dev
+  # install Xapian 1.2.19
+  - curl https://gist.githubusercontent.com/jorgecarleitao/45c312987f0d0e0f843d/raw/d27dbae4fb2a293bbba5067038399f204bb8b6e7 | bash -s 1.2.19
 
 # move xapian-haystack to django-haystack
 before_script:

--- a/README.rst
+++ b/README.rst
@@ -35,10 +35,10 @@ Requirements
 
 In particular, we build this backend on `Travis`_ using:
 
-- Python 2.7.6
+- Python 2.7 and 3.3
 - Django 1.6, 1.7 and 1.8
 - Django-Haystack (master)
-- Xapian 1.2.8 (libxapian22)
+- Xapian 1.2.19
 
 
 Installation


### PR DESCRIPTION
I've updated the installation in travis to support arbitrary versions of Python.

This allowed me to add Python 3.3 to the build matrix.

I've also updated Xapian to 1.2.19 on the tests, and to Django 1.6.x.

We now have to wait for a version of Xapian that supports Python 3.3, and we are hopefully done.

In principle this PR will fix issue #128.