### PR TITLE
Configurable Stemming Strategy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,11 @@ The backend has the following optional settings:
   See `here <http://xapian.org/docs/apidoc/html/classXapian_1_1QueryParser.html>`_ for more information
   on what they mean.
 
+- ``HAYSTACK_XAPIAN_STEMMING_STRATEGY``: This option lets you chose the stemming strategy used by Xapian. Possible
+  values are ``STEM_NONE``, ``STEM_SOME``, ``STEM_ALL``, ``STEM_ALL_Z``, where ``STEM_SOME`` is the default.
+  See `here <http://xapian.org/docs/apidoc/html/classXapian_1_1QueryParser.html#ac7dc3b55b6083bd3ff98fc8b2726c8fd>`_ for
+  more information about the different strategies.
+
 
 Testing
 -------

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -192,6 +192,9 @@ class XapianSearchBackend(BaseSearchBackend):
         self.flags = connection_options.get('FLAGS', DEFAULT_XAPIAN_FLAGS)
         self.language = getattr(settings, 'HAYSTACK_XAPIAN_LANGUAGE', 'english')
 
+        stemming_strategy_string = getattr(settings, 'HAYSTACK_XAPIAN_STEMMING_STRATEGY', 'STEM_SOME')
+        self.stemming_strategy = getattr(xapian.QueryParser, stemming_strategy_string, xapian.QueryParser.STEM_SOME)
+
         # these 4 attributes are caches populated in `build_schema`
         # they are checked in `_update_cache`
         # use property to retrieve them
@@ -273,6 +276,7 @@ class XapianSearchBackend(BaseSearchBackend):
             term_generator = xapian.TermGenerator()
             term_generator.set_database(database)
             term_generator.set_stemmer(xapian.Stem(self.language))
+            term_generator.set_stemming_strategy(self.stemming_strategy)
             if self.include_spelling is True:
                 term_generator.set_flags(xapian.TermGenerator.FLAG_SPELLING)
 
@@ -805,7 +809,7 @@ class XapianSearchBackend(BaseSearchBackend):
         qp = xapian.QueryParser()
         qp.set_database(self._database())
         qp.set_stemmer(xapian.Stem(self.language))
-        qp.set_stemming_strategy(xapian.QueryParser.STEM_SOME)
+        qp.set_stemming_strategy(self.stemming_strategy)
         qp.set_default_op(XAPIAN_OPTS[DEFAULT_OPERATOR])
         qp.add_boolean_prefix('django_ct', TERM_PREFIXES['django_ct'])
 

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -276,7 +276,11 @@ class XapianSearchBackend(BaseSearchBackend):
             term_generator = xapian.TermGenerator()
             term_generator.set_database(database)
             term_generator.set_stemmer(xapian.Stem(self.language))
-            term_generator.set_stemming_strategy(self.stemming_strategy)
+            try:
+                term_generator.set_stemming_strategy(self.stemming_strategy)
+            except AttributeError:  
+                # Versions before Xapian 1.2.11 do not support stemming strategies for TermGenerator
+                pass
             if self.include_spelling is True:
                 term_generator.set_flags(xapian.TermGenerator.FLAG_SPELLING)
 


### PR DESCRIPTION
This pull request is based on the discussion in #141 , see there for more information.

What I've done is basically this:
  - Made the stemming strategy configurable and fixed the missing `set_stemming_strategy()` in `update()`.
  - Added some documentation in the readme for this new config value.

Note that Travis is using xapian 1.2.8, which does not include the stemming strategy for the term generator.