### PR TITLE
add commit argument to update

### DIFF
--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -232,7 +232,7 @@ class XapianSearchBackend(BaseSearchBackend):
         self._update_cache()
         return self._columns
 
-    def update(self, index, iterable):
+    def update(self, index, iterable, commit=True):
         """
         Updates the `index` with any objects in `iterable` by adding/updating
         the database as needed.
@@ -240,6 +240,7 @@ class XapianSearchBackend(BaseSearchBackend):
         Required arguments:
             `index` -- The `SearchIndex` to process
             `iterable` -- An iterable of model instances to index
+            `commit` -- ignored (present for compatibility with django-haystack 1.4)
 
         For each object in `iterable`, a document is created containing all
         of the terms extracted from `index.full_prepare(obj)` with field prefixes,

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -240,6 +240,7 @@ class XapianSearchBackend(BaseSearchBackend):
         Required arguments:
             `index` -- The `SearchIndex` to process
             `iterable` -- An iterable of model instances to index
+        Optional arguments:
             `commit` -- ignored (present for compatibility with django-haystack 1.4)
 
         For each object in `iterable`, a document is created containing all


### PR DESCRIPTION
For compatibility with (not yet released) django-haystack 1.4 which calls update method with a new argument "commit". It does not apply here (I think) but we should not fail when we receive it.