### PR TITLE
Fix UnicodeDecodeError in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import io
 import os
 from distutils.core import setup
 
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return io.open(os.path.join(os.path.dirname(__file__), fname), encoding="utf-8").read()
 
 setup(
     name='xapian-haystack',


### PR DESCRIPTION
Fixes this error while installing inside python3.4 venv using tox:
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 3589: ordinal not in range(128)
