### PR TITLE
Correction in filter api (django_ct)

### DIFF
--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -674,7 +674,7 @@ class XapianSearchBackend(BaseSearchBackend):
             for spy in facets_spies:
                 enquire.add_matchspy(spy)
 
-        print enquire.get_query()
+        # print enquire.get_query()
 
         matches = self._get_enquire_mset(database, enquire, start_offset, end_offset)
 
@@ -1433,7 +1433,7 @@ class XapianSearchQuery(BaseSearchQuery):
 
         Assumes term is not a list.
         """
-        if field_type == 'text':
+        if field_type == 'text' and field_name not in ('django_ct',):
             term = '^ %s $' % term
             query = self._phrase_query(term.split(), field_name, field_type)
         else:

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -576,7 +576,7 @@ class XapianSearchBackend(BaseSearchBackend):
     def search(self, query, sort_by=None, start_offset=0, end_offset=None,
                fields='', highlight=False, facets=None, date_facets=None,
                query_facets=None, narrow_queries=None, spelling_query=None,
-               limit_to_registered_models=True, result_class=None, **kwargs):
+               limit_to_registered_models=None, result_class=None, **kwargs):
         """
         Executes the Xapian::query as defined in `query`.
 
@@ -626,6 +626,9 @@ class XapianSearchBackend(BaseSearchBackend):
 
         database = self._database()
 
+        if limit_to_registered_models is None:
+            limit_to_registered_models = getattr(settings, 'HAYSTACK_LIMIT_TO_REGISTERED_MODELS', True)
+
         if result_class is None:
             result_class = SearchResult
 
@@ -670,6 +673,8 @@ class XapianSearchBackend(BaseSearchBackend):
             facets_spies = self._prepare_facet_field_spies(facets)
             for spy in facets_spies:
                 enquire.add_matchspy(spy)
+
+        print enquire.get_query()
 
         matches = self._get_enquire_mset(database, enquire, start_offset, end_offset)
 


### PR DESCRIPTION
According to the issue [#165](https://github.com/notanumber/xapian-haystack/issues/165)
It is possible to perceive the problem that I was facing.

This bug was generated by the following commit: [#ec0d7](https://github.com/alexsilva/xapian-haystack/commit/ec0d7091fc814555dfd2acb850bc4912d4378a2b)

Which changed the filter syntax, regardless reserved fields.
