### PR TITLE
Fixing untrustable os.path.exists

### DIFF
--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -193,8 +193,11 @@ class XapianSearchBackend(BaseSearchBackend):
 
         self.path = connection_options.get('PATH')
 
-        if self.path != MEMORY_DB_NAME and not os.path.exists(self.path):
-            os.makedirs(self.path)
+        if self.path != MEMORY_DB_NAME:
+            try:
+                os.makedirs(self.path)
+            except FileExistsError:
+                pass
 
         self.flags = connection_options.get('FLAGS', DEFAULT_XAPIAN_FLAGS)
         self.language = getattr(settings, 'HAYSTACK_XAPIAN_LANGUAGE', 'english')


### PR DESCRIPTION
As per https://stackoverflow.com/a/3112717/1067833,
os.path.exists sometimes delivers a wrong value. These are corner
cases, but mine is exactly one:

I run xapian-haystack in a multiprocess environment (indexing and
django server), on an LXC container, which has its mount probably
mounted from an NFS server (I have no control/information over it).

This corner case results the os.path.exists give `True` for one
process and `False` for another, resulting in the exception I
handle with this patch.