### PR TITLE
Add encoding in read function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ from distutils.core import setup
 
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(os.path.join(os.path.dirname(__file__), fname),
+                encoding='utf-8').read()
 
 setup(
     name='xapian-haystack',


### PR DESCRIPTION
On FreeBSD 11.1 this package fails to build due to an encoding error in the `setup.py` `read()` function. By explicitly setting `encoding='utf-8'` in the read function this problem is resolved.