### PR TITLE
Add Xapian Omega solution to haystack backend to fix long term issues

### DIFF
--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -1653,7 +1653,7 @@ def _ensure_term_length(text):
             hole = hole[:LONG_TERM_LENGTH]
         elif LONG_TERM_METHOD == 'hash':
             from hashlib import sha224
-            hole = sha224(hole.encode('utf8')).hexdigest()
+            hole = sha224(hole).hexdigest().encode('utf8')
         text = text[:match.start()] + hole + text[match.end():]
 
     # We ignore any errors because truncate may have chopped a unicode in half.


### PR DESCRIPTION
Inside the xapian project, they have solved the "Term Too Long" error by providing two different options inside their omega side project, one is to truncate the terms and the other is to hash the terms.

See: https://lists.xapian.org/pipermail/xapian-discuss/2007-March/003450.html for example.

This commit adds this capability to this haystack backend. It's been tested with ascii, urls, japonese and strings of emoji on python 3.6, django 1.11.15 in both management command and real time updating.