### PR TITLE
limit 'content' search to only search the document field

### DIFF
--- a/tests/xapian_tests/tests/test_interface.py
+++ b/tests/xapian_tests/tests/test_interface.py
@@ -73,6 +73,12 @@ class InterfaceTestCase(TestCase):
         # documents with "medium" AND "this" have higher score
         self.assertEqual(pks(result)[:4], [1, 4, 7, 10])
 
+    def test_content_search2(self):
+        # content should only search the document, not all fields.
+        result = self.queryset.filter(content='summary')
+        self.assertEqual(pks(result), [])
+
+
     def test_field_search(self):
         self.assertEqual(pks(self.queryset.filter(name__contains='8')), [4])
         self.assertEqual(pks(self.queryset.filter(type_name='book')),

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -1314,10 +1314,9 @@ class XapianSearchQuery(BaseSearchQuery):
         # It it is an AutoQuery, it has no filters
         # or others, thus we short-circuit the procedure.
         if isinstance(term, AutoQuery):
-            if field_name != 'content':
-                query = '%s:%s' % (field_name, term.prepare(self))
-            else:
-                query = term.prepare(self)
+            if field_name == 'content':
+                field_name = self.backend.content_field_name
+            query = '%s:%s' % (field_name, term.prepare(self))
             return [self.backend.parse_query(query)]
         query_list = []
 
@@ -1326,10 +1325,10 @@ class XapianSearchQuery(BaseSearchQuery):
             term = list(term)
 
         if field_name == 'content':
-            # content is the generic search:
-            # force no field_name search
+            # content is the document search:
+            # adjust field_name to point to the document field
             # and the field_type to be 'text'.
-            field_name = None
+            field_name = self.backend.content_field_name
             field_type = 'text'
 
             # we don't know what is the type(term), so we parse it.


### PR DESCRIPTION
As per the haystack documentation [1] the `content` field is a special
term for the field marked `document=True`. This change impements that
behavior.

[1] https://django-haystack.readthedocs.io/en/master/searchqueryset_api.html#the-content-shortcut