### PR TITLE
bugfix: don't crash when filtering FloatFields using lt, lte, gt, gte, and range

### DIFF
--- a/tests/xapian_tests/models.py
+++ b/tests/xapian_tests/models.py
@@ -7,6 +7,7 @@ from ..core.models import MockTag, AnotherMockModel, MockModel, AFourthMockModel
 class Document(models.Model):
     type_name = models.CharField(max_length=50)
     number = models.IntegerField()
+    float_number = models.FloatField()
     name = models.CharField(max_length=200)
 
     date = models.DateField()

--- a/tests/xapian_tests/search_indexes.py
+++ b/tests/xapian_tests/search_indexes.py
@@ -12,6 +12,7 @@ class DocumentIndex(indexes.SearchIndex, indexes.Indexable):
     type_name = indexes.CharField(model_attr='type_name')
 
     number = indexes.IntegerField(model_attr='number')
+    float_number = indexes.FloatField(model_attr='float_number')
 
     name = indexes.CharField(model_attr='name')
     date = indexes.DateField(model_attr='date')

--- a/tests/xapian_tests/tests/test_interface.py
+++ b/tests/xapian_tests/tests/test_interface.py
@@ -41,6 +41,7 @@ class InterfaceTestCase(TestCase):
             doc = Document()
             doc.type_name = types_names[i % 3]
             doc.number = i * 2
+            doc.float_number = (i - 6.5) * 2
             doc.name = "%s %d" % (doc.type_name, doc.number)
             doc.date = dates[i % 3]
 
@@ -159,6 +160,11 @@ class InterfaceTestCase(TestCase):
     def test_value_range(self):
         self.assertEqual(set(pks(self.queryset.filter(number__lt=3))),
                          set(pks(Document.objects.filter(number__lt=3))))
+
+        self.assertEqual(set(pks(self.queryset.filter(float_number__lt=4))),
+                         set(pks(self.queryset.filter(float_number__lt=4))))
+        self.assertEqual(set(pks(self.queryset.filter(float_number__lt=4.5))),
+                         set(pks(self.queryset.filter(float_number__lt=4.5))))
 
         self.assertEqual(set(pks(self.queryset.filter(django_id__gte=6))),
                          set(pks(Document.objects.filter(id__gte=6))))


### PR DESCRIPTION
This feels pretty hacky. I tried doing all conversions in XHValueRangeProcessor but gave up after a while.