### PR TITLE
fix filter and ordering issues with FloatField and IntegerField

### DIFF
--- a/install_xapian.sh
+++ b/install_xapian.sh
@@ -43,9 +43,10 @@ else
     XAPIAN_CONFIG=
 fi
 
-# The bindings for Python require python-sphinx
+# The bindings for Python require python-sphinx but fail to build with sphinx >= 2.0
+# because they check for sphinx.main which is gone in sphinx >= 2.0
 echo "Installing Python-Sphinx..."
-pip install sphinx
+pip install 'sphinx<2.0'
 
 echo "Installing Xapian-bindings..."
 cd $VIRTUAL_ENV/packages/${BINDINGS}

--- a/tests/xapian_tests/models.py
+++ b/tests/xapian_tests/models.py
@@ -7,6 +7,7 @@ from ..core.models import MockTag, AnotherMockModel, MockModel, AFourthMockModel
 class Document(models.Model):
     type_name = models.CharField(max_length=50)
     number = models.IntegerField()
+    float_number = models.FloatField()
     name = models.CharField(max_length=200)
 
     date = models.DateField()

--- a/tests/xapian_tests/search_indexes.py
+++ b/tests/xapian_tests/search_indexes.py
@@ -12,6 +12,7 @@ class DocumentIndex(indexes.SearchIndex, indexes.Indexable):
     type_name = indexes.CharField(model_attr='type_name')
 
     number = indexes.IntegerField(model_attr='number')
+    float_number = indexes.FloatField(model_attr='float_number')
 
     name = indexes.CharField(model_attr='name')
     date = indexes.DateField(model_attr='date')

--- a/tests/xapian_tests/tests/test_backend.py
+++ b/tests/xapian_tests/tests/test_backend.py
@@ -569,7 +569,7 @@ class BackendFeaturesTestCase(HaystackBackendTestCase, TestCase):
         self.assertEqual(_term_to_xapian_value('abc', 'text'), 'abc')
         self.assertEqual(_term_to_xapian_value(1, 'integer'), '000000000001')
         self.assertEqual(_term_to_xapian_value(2653, 'integer'), '000000002653')
-        self.assertEqual(_term_to_xapian_value(25.5, 'float'), b'\xb2`')
+        self.assertEqual(_term_to_xapian_value(25.5, 'float'), 'b260')
         self.assertEqual(_term_to_xapian_value([1, 2, 3], 'text'), '[1, 2, 3]')
         self.assertEqual(_term_to_xapian_value((1, 2, 3), 'text'), '(1, 2, 3)')
         self.assertEqual(_term_to_xapian_value({'a': 1, 'c': 3, 'b': 2}, 'text'),

--- a/tests/xapian_tests/tests/test_backend.py
+++ b/tests/xapian_tests/tests/test_backend.py
@@ -567,8 +567,9 @@ class BackendFeaturesTestCase(HaystackBackendTestCase, TestCase):
 
     def test_term_to_xapian_value(self):
         self.assertEqual(_term_to_xapian_value('abc', 'text'), 'abc')
-        self.assertEqual(_term_to_xapian_value(1, 'integer'), '000000000001')
-        self.assertEqual(_term_to_xapian_value(2653, 'integer'), '000000002653')
+        self.assertEqual(_term_to_xapian_value(-1337, 'integer'), '316380')
+        self.assertEqual(_term_to_xapian_value(1, 'integer'), 'a0')
+        self.assertEqual(_term_to_xapian_value(2653, 'integer'), 'd12e80')
         self.assertEqual(_term_to_xapian_value(25.5, 'float'), 'b260')
         self.assertEqual(_term_to_xapian_value([1, 2, 3], 'text'), '[1, 2, 3]')
         self.assertEqual(_term_to_xapian_value((1, 2, 3), 'text'), '(1, 2, 3)')
@@ -641,22 +642,22 @@ class BackendFeaturesTestCase(HaystackBackendTestCase, TestCase):
                                  xapian12string='VALUE_RANGE 9 david1 david2')
         self.assertExpectedQuery(self.backend.parse_query('number:0..10'),
                                  [
-                                     '0 * VALUE_RANGE 11 000000000000 000000000010',
-                                     'VALUE_RANGE 11 000000000000 000000000010',
+                                     '0 * VALUE_RANGE 11 80 ad',
+                                     'VALUE_RANGE 11 80 ad',
                                  ],
-                                 xapian12string='VALUE_RANGE 11 000000000000 000000000010')
+                                 xapian12string='VALUE_RANGE 11 80 ad')
         self.assertExpectedQuery(self.backend.parse_query('number:..10'),
                                  [
-                                     '0 * VALUE_RANGE 11 %012d 000000000010' % (-sys.maxsize - 1),
-                                     'VALUE_RANGE 11 %012d 000000000010' % (-sys.maxsize - 1),
+                                     '0 * VALUE_LE 11 ad',
+                                     'VALUE_LE 11 ad',
                                  ],
-                                 xapian12string='VALUE_RANGE 11 %012d 000000000010' % (-sys.maxsize - 1))
+                                 xapian12string='VALUE_LE 11 ad')
         self.assertExpectedQuery(self.backend.parse_query('number:10..*'),
                                  [
-                                     '0 * VALUE_RANGE 11 000000000010 %012d' % sys.maxsize,
-                                     'VALUE_RANGE 11 000000000010 %012d' % sys.maxsize,
+                                     '0 * VALUE_RANGE 11 ad ffffffffffffffffff',
+                                     'VALUE_RANGE 11 ad ffffffffffffffffff',
                                  ],
-                                 xapian12string='VALUE_RANGE 11 000000000010 %012d' % sys.maxsize)
+                                 xapian12string='VALUE_RANGE 11 ad ffffffffffffffffff')
 
     def test_order_by_django_id(self):
         """

--- a/tests/xapian_tests/tests/test_backend.py
+++ b/tests/xapian_tests/tests/test_backend.py
@@ -648,10 +648,10 @@ class BackendFeaturesTestCase(HaystackBackendTestCase, TestCase):
                                  xapian12string='VALUE_RANGE 11 80 ad')
         self.assertExpectedQuery(self.backend.parse_query('number:..10'),
                                  [
-                                     '0 * VALUE_LE 11 ad',
-                                     'VALUE_LE 11 ad',
+                                     '0 * VALUE_RANGE 11 00 ad',
+                                     'VALUE_RANGE 11 00 ad',
                                  ],
-                                 xapian12string='VALUE_LE 11 ad')
+                                 xapian12string='VALUE_RANGE 11 00 ad')
         self.assertExpectedQuery(self.backend.parse_query('number:10..*'),
                                  [
                                      '0 * VALUE_RANGE 11 ad ffffffffffffffffff',

--- a/tests/xapian_tests/tests/test_interface.py
+++ b/tests/xapian_tests/tests/test_interface.py
@@ -40,9 +40,9 @@ class InterfaceTestCase(TestCase):
         for i in range(1, 13):
             doc = Document()
             doc.type_name = types_names[i % 3]
-            doc.number = i * 2
+            doc.number = (i - 7) * 100
             doc.float_number = (i - 6.5) * 2
-            doc.name = "%s %d" % (doc.type_name, doc.number)
+            doc.name = "%s %d" % (doc.type_name, i * 2)
             doc.date = dates[i % 3]
 
             doc.summary = summaries[i % 3]
@@ -161,10 +161,14 @@ class InterfaceTestCase(TestCase):
         self.assertEqual(set(pks(self.queryset.filter(number__lt=3))),
                          set(pks(Document.objects.filter(number__lt=3))))
 
+        self.assertEqual(set(pks(self.queryset.filter(float_number__lte=float('inf')))),
+                         set(pks(Document.objects.filter(float_number__lte=float('inf')))))
         self.assertEqual(set(pks(self.queryset.filter(float_number__lt=3.5))),
                          set(pks(Document.objects.filter(float_number__lt=3.5))))
         self.assertEqual(set(pks(self.queryset.filter(float_number__gt=3.5))),
                          set(pks(Document.objects.filter(float_number__gt=3.5))))
+        self.assertEqual(set(pks(self.queryset.filter(float_number__gte=float('-inf')))),
+                         set(pks(Document.objects.filter(float_number__gte=float('-inf')))))
 
         self.assertEqual(set(pks(self.queryset.filter(django_id__gte=6))),
                          set(pks(Document.objects.filter(id__gte=6))))
@@ -186,6 +190,8 @@ class InterfaceTestCase(TestCase):
         # value order
         self.assertEqual(pks(self.queryset.order_by("number")),
                          pks(Document.objects.order_by("number")))
+        self.assertEqual(pks(self.queryset.order_by("float_number")),
+                         pks(Document.objects.order_by("float_number")))
 
         # text order
         self.assertEqual(pks(self.queryset.order_by("summary")),

--- a/tests/xapian_tests/tests/test_interface.py
+++ b/tests/xapian_tests/tests/test_interface.py
@@ -41,6 +41,7 @@ class InterfaceTestCase(TestCase):
             doc = Document()
             doc.type_name = types_names[i % 3]
             doc.number = i * 2
+            doc.float_number = (i - 6.5) * 2
             doc.name = "%s %d" % (doc.type_name, doc.number)
             doc.date = dates[i % 3]
 
@@ -159,6 +160,11 @@ class InterfaceTestCase(TestCase):
     def test_value_range(self):
         self.assertEqual(set(pks(self.queryset.filter(number__lt=3))),
                          set(pks(Document.objects.filter(number__lt=3))))
+
+        self.assertEqual(set(pks(self.queryset.filter(float_number__lt=3.5))),
+                         set(pks(Document.objects.filter(float_number__lt=3.5))))
+        self.assertEqual(set(pks(self.queryset.filter(float_number__gt=3.5))),
+                         set(pks(Document.objects.filter(float_number__gt=3.5))))
 
         self.assertEqual(set(pks(self.queryset.filter(django_id__gte=6))),
                          set(pks(Document.objects.filter(id__gte=6))))

--- a/tests/xapian_tests/tests/test_query.py
+++ b/tests/xapian_tests/tests/test_query.py
@@ -290,26 +290,21 @@ class SearchQueryTestCase(HaystackBackendTestCase, TestCase):
     def test_gt(self):
         self.sq.add_filter(SQ(name__gt='m'))
         self.assertExpectedQuery(self.sq.build_query(),
-                                 '(<alldocuments> AND_NOT VALUE_RANGE 3 a m)')
+                                 '(<alldocuments> AND_NOT VALUE_LE 3 m)')
 
     def test_gte(self):
         self.sq.add_filter(SQ(name__gte='m'))
         self.assertExpectedQuery(self.sq.build_query(),
-                                 'VALUE_RANGE 3 m zzzzzzzzzzzzzzzzzzzzzzzzzzzz'
-                                 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
-                                 'zzzzzzzzzzzzzzzzzzzzzzzzzzzz')
+                                 'VALUE_GE 3 m')
 
     def test_lt(self):
         self.sq.add_filter(SQ(name__lt='m'))
         self.assertExpectedQuery(self.sq.build_query(),
-                                 '(<alldocuments> AND_NOT VALUE_RANGE 3 m '
-                                 'zzzzzzzzzzzzzzzzzzzzzzzzzzzz'
-                                 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
-                                 'zzzzzzzzzzzzzzzzzzzzzzzzzzzz)')
+                                 '(<alldocuments> AND_NOT VALUE_GE 3 m)')
 
     def test_lte(self):
         self.sq.add_filter(SQ(name__lte='m'))
-        self.assertExpectedQuery(self.sq.build_query(), 'VALUE_RANGE 3 a m')
+        self.assertExpectedQuery(self.sq.build_query(), 'VALUE_LE 3 m')
 
     def test_range(self):
         self.sq.add_filter(SQ(django_id__range=[2, 4]))
@@ -327,13 +322,11 @@ class SearchQueryTestCase(HaystackBackendTestCase, TestCase):
         self.sq.add_filter(SQ(title__gte='B'))
         self.sq.add_filter(SQ(django_id__in=[1, 2, 3]))
         self.assertExpectedQuery(self.sq.build_query(),
-                                 '((Zwhi OR why) AND'
-                                 ' VALUE_RANGE 5 00010101000000 20090210015900 AND'
-                                 ' (<alldocuments> AND_NOT VALUE_RANGE 3 a david)'
-                                 ' AND VALUE_RANGE 7 b zzzzzzzzzzzzzzzzzzzzzzzzzzz'
-                                 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
-                                 'zzzzzzzzzzzzzzzzzzzzzzzzz AND'
-                                 ' (QQ000000000001 OR QQ000000000002 OR QQ000000000003))')
+                                 '((Zwhi OR why) AND '
+                                 'VALUE_LE 5 20090210015900 AND '
+                                 '(<alldocuments> AND_NOT VALUE_LE 3 david) AND '
+                                 'VALUE_GE 7 b AND '
+                                 '(QQ000000000001 OR QQ000000000002 OR QQ000000000003))')
 
     def test_log_query(self):
         reset_search_queries()

--- a/tests/xapian_tests/tests/test_query.py
+++ b/tests/xapian_tests/tests/test_query.py
@@ -308,11 +308,11 @@ class SearchQueryTestCase(HaystackBackendTestCase, TestCase):
 
     def test_range(self):
         self.sq.add_filter(SQ(django_id__range=[2, 4]))
-        self.assertExpectedQuery(self.sq.build_query(), 'VALUE_RANGE 1 000000000002 000000000004')
+        self.assertExpectedQuery(self.sq.build_query(), 'VALUE_RANGE 1 a4 a8')
         self.sq.add_filter(~SQ(django_id__range=[0, 2]))
         self.assertExpectedQuery(self.sq.build_query(),
-                                 '(VALUE_RANGE 1 000000000002 000000000004 AND '
-                                 '(<alldocuments> AND_NOT VALUE_RANGE 1 000000000000 000000000002))')
+                                 '(VALUE_RANGE 1 a4 a8 AND '
+                                 '(<alldocuments> AND_NOT VALUE_RANGE 1 80 a4))')
         self.assertEqual([result.pk for result in self.sq.get_results()], [3])
 
     def test_multiple_filter_types(self):
@@ -326,7 +326,7 @@ class SearchQueryTestCase(HaystackBackendTestCase, TestCase):
                                  'VALUE_LE 5 20090210015900 AND '
                                  '(<alldocuments> AND_NOT VALUE_LE 3 david) AND '
                                  'VALUE_GE 7 b AND '
-                                 '(QQ000000000001 OR QQ000000000002 OR QQ000000000003))')
+                                 '(QQa0 OR QQa4 OR QQa6))')
 
     def test_log_query(self):
         reset_search_queries()

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -124,12 +124,19 @@ class XHValueRangeProcessor(xapian.ValueRangeProcessor):
                     elif field_type == 'integer':
                         begin = _term_to_xapian_value(int(begin), field_type)
                 else:
+                    # TODO: when we drop support for xapian 1.2, we can simply
+                    # return empty strings for begin and end, and xapian would
+                    # turn the VALUE_RANGE query into VALUE_GE and VALUE_LE
+                    # queries instead.
                     if field_type == 'text':
                         begin = 'a'  # TODO: A better way of getting a min text value?
                     elif field_type in ('float', 'integer'):
-                        # floats and ints are both serialised using xapian.sortable_serialise
-                        # so we can use -Infinity as the lower bound for both of them.
-                        begin = _term_to_xapian_value(float('-inf'), field_type)
+                        # floats and ints are both serialised using xapian.sortable_serialise.
+                        # Unfortunately, we can't use -Infinity as the lower bound because
+                        # it serialises to '', which doesn't work with xapian 1.2
+                        # However, even -2**1023 serialises to '101e' so '00' would compare less
+                        # to that (and probably all other double values).
+                        begin = '00'
                     elif field_type == 'date' or field_type == 'datetime':
                         begin = '00010101000000'
 


### PR DESCRIPTION
Filtering on FloatFields crashed with a ValueError because it tried to convert the already serialised float back into an actual float. Also, in Python 3 `xapian.sortable_serialise()` returns `bytes` instead of `str` which we then can't use any further (because `xapian.Query` expects a unicode string). So we now store the hex encoded result of `sortable_serialise()` which has the same sort order as the result of `sortable_serialise()` itself.

Ordering on IntegerFields with negative values didn't produce the expected results because the integer format produced the following order: -000000000001, -000000000002, -000000000003, 000000000000, 000000000001, 000000000002, 000000000003. By storing integers the same way as floats, i.e. hex encode the result of `xapian.sortable_serialise()`, we get the correct order. Note that `sortable_serialise()` deals with doubles but a double can store integers up to 2**53 without any loss of precision.

I also noticed that Xapian 1.4 allows returning empty strings for `begin` and `end` from a ValueRangeProcessor and then turns the `VALUE_RANGE` query into `VALUE_LE` and `VALUE_GE` query respectively, which would greatly simplify the `XHValueRangeProcessor`. However, this does not work with Xapian 1.2 (and I didn't check Xapian 1.3).