### PR TITLE
install_xapian.sh: pin sphinx to avoid compatibility issues with 2.0

### DIFF
--- a/install_xapian.sh
+++ b/install_xapian.sh
@@ -45,7 +45,7 @@ fi
 
 # The bindings for Python require python-sphinx
 echo "Installing Python-Sphinx..."
-pip install sphinx
+pip install "sphinx<2"
 
 echo "Installing Xapian-bindings..."
 cd $VIRTUAL_ENV/packages/${BINDINGS}


### PR DESCRIPTION
This should fix the build for now.