### PR TITLE
xapian_wheel_builder.sh

### DIFF
--- a/xapian_wheel_builder.sh
+++ b/xapian_wheel_builder.sh
@@ -33,15 +33,13 @@ for sig in 1 2 13 15; do trap "exit $(($sig + 128))" $sig; done
 trap 'exittrap' EXIT
 
 WHL_DEST=$(pwd)
-if [ "x${WORKSPACE}" = "x" ]; then
-    WORKSPACE=$(mktemp -d -t "xapian-builder-XXXXXX") || die "Unable to mktemp"
-    exittrap() { rm -rf "${WORKSPACE}"; }
-fi
-echo "Building in ${WORKSPACE}."
-pushd ${WORKSPACE}
+TMPDIR=$(mktemp -d -t "xapian-builder-XXXXXX") || die "Unable to mktemp"
+exittrap() { rm -rf "${TMPDIR}"; }
+echo "Building in ${TMPDIR}."
+pushd ${TMPDIR}
 
 echo "Preparing build virtualenv..."
-VE="${WORKSPACE}/ve"
+VE="${TMPDIR}/ve"
 ${PYTHON} -m venv ${VE}
 ${VE}/bin/python -m pip install --upgrade pip wheel setuptools
 
@@ -68,7 +66,7 @@ tar -C src -xf "${BINDINGS}.tar.xz"
 # building xapian-core
 mkdir target
 
-prefix=${WORKSPACE}/target
+prefix=${TMPDIR}/target
 pprefix=${prefix}
 case "${uname_sysname}" in
     Linux)
@@ -161,5 +159,5 @@ EOF
     cp dist/*.whl ${WHL_DEST}
 )
 popd
-rm -rf "${WORKSPACE}"
+rm -rf "${TMPDIR}"
 exittrap() { :; }

--- a/xapian_wheel_builder.sh
+++ b/xapian_wheel_builder.sh
@@ -88,7 +88,7 @@ mkdir target
 prefix=${TMPDIR}/target
 pprefix=${prefix}
 case "${uname_sysname}" in
-    Linux)
+    Linux|FreeBSD)
     while [ ${#pprefix} -lt 7 ]; do
         # add padding as needed
         pprefix=${pprefix}/.

--- a/xapian_wheel_builder.sh
+++ b/xapian_wheel_builder.sh
@@ -22,9 +22,19 @@ for opt; do
     esac
 done
 
+usage() {
+    echo "usage: $0 [-p <path-to-python3>] version_number" 1>&2
+}
+
 VERSION=${1-${XAPIAN_VERSION}}
 if [ -z "${VERSION}" ]; then
-    echo "usage: $0 [-p <path-to-python3>] version_number" 1>&2
+    usage
+    exit 1
+fi
+
+if [ -z "${PYTHON}" -o ! -x "${PYTHON}" ]; then
+    usage
+    echo "error: could not find python3, please specify with -p" 1>&2
     exit 1
 fi
 

--- a/xapian_wheel_builder.sh
+++ b/xapian_wheel_builder.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+
+uname_sysname="$(uname -s)"
+case "${uname_sysname}" in
+    Linux)
+        ;;
+    Darwin)
+        ;;
+    *)
+        echo "Platform ${uname_sysname} is not supported"
+        exit 1
+esac
+
+exittrap() { :; }
+for sig in 1 2 13 15; do trap "exit $(($sig + 128))" $sig; done
+trap 'exittrap' EXIT
+
+WHL_DEST=$(pwd)
+if [ "x${WORKSPACE}" = "x" ]; then
+    WORKSPACE=$(mktemp -d -t "xapian-builder-XXXXXX") || die "Unable to mktemp"
+    exittrap() { rm -rf "${WORKSPACE}"; }
+fi
+echo "Building in ${WORKSPACE}."
+pushd ${WORKSPACE}
+
+echo "Preparing build virtualenv..."
+VE="${WORKSPACE}/ve"
+python3 -m venv ${VE}
+${VE}/bin/pip install --upgrade pip wheel setuptools
+${VE}/bin/pip install "sphinx<2"
+
+VERS=${XAPIAN_VERSION-1.4.9}
+CORE="xapian-core-${VERS}"
+BINDINGS="xapian-bindings-${VERS}"
+
+echo "Downloading source..."
+curl -O https://oligarchy.co.uk/xapian/${VERS}/${CORE}.tar.xz
+curl -O https://oligarchy.co.uk/xapian/${VERS}/${BINDINGS}.tar.xz
+
+echo "Extracting source..."
+mkdir src
+tar -C src -xf "${CORE}.tar.xz"
+tar -C src -xf "${BINDINGS}.tar.xz"
+
+# building xapian-core
+mkdir target
+
+prefix=${WORKSPACE}/target
+pprefix=${prefix}
+case "${uname_sysname}" in
+    Linux)
+    while [ ${#pprefix} -lt 7 ]; do
+        # add padding as needed
+        pprefix=${pprefix}/.
+    done
+    ;;
+esac
+
+echo "Building xapian core..."
+(
+    cd src/${CORE}
+    ./configure --prefix=${pprefix}
+    make
+    make install
+)
+
+XAPIAN_CONFIG=${prefix}/bin/xapian-config*
+
+echo "Building xapian python3 bindings..."
+(
+    cd src/${BINDINGS}
+    # We're building python3 bindings here, and we need to contort things to make it work.
+    # We want the xapian-config we just built.
+    # We want the sphinx we just put in a virtualenv because the xapian bindings insist on making their docs.
+    # We use the python3 from that same virtualenv, because the xapian bindings don't use the shebang line of sphinx-build.
+    # We override PYTHON3_LIB because if we don't then the bindings will be installed in the virutalenv, despite what we set prefix to.
+    ./configure --prefix=$prefix --with-python3 XAPIAN_CONFIG=${XAPIAN_CONFIG} SPHINX_BUILD=${VE}/bin/sphinx-build PYTHON3=${VE}/bin/python3 PYTHON3_LIB=${prefix}
+    make
+    make install
+)
+
+echo "preparing xapian wheel..."
+for file in $(find ${prefix}/xapian -name '*.so'); do
+    case "${uname_sysname}" in
+        Linux)
+            # Binary patch rpath to be '$ORIGIN' as needed.
+            rpath_offset=$(strings -t d ${file} | grep "${pprefix}/lib" | awk '{ printf $1; }')
+            printf "\$ORIGIN\x00" | dd of=${file} obs=1 seek=${rpath_offset} conv=notrunc 2>/dev/null
+            # Verify
+            readelf -d ${file} | grep RPATH | grep -q ORIGIN
+            libxapian_name=$(ldd $file | grep libxapian | awk '{ printf $1; }')
+            ;;
+        Darwin)
+            libxapian_name=$(otool -L $file | grep -o libxapian.* | awk '{ printf $1; }')
+            install_name_tool -change "${prefix}/lib/${libxapian_name}" "@loader_path/${libxapian_name}" "${file}"
+            ;;
+    esac
+done
+
+# Copy libxapian into place alongside the python bindings.
+cp "${prefix}/lib/${libxapian_name}" "${prefix}/xapian"
+case "${uname_sysname}" in
+    Darwin)
+        install_name_tool -id "@loader_path/${libxapian_name}" "${prefix}/xapian/${libxapian_name}"
+        ;;
+esac
+
+# Prepare the scaffolding for the wheel
+cat > $prefix/setup.py <<EOF
+from setuptools import setup
+
+try:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+    class bdist_wheel(_bdist_wheel):
+        def finalize_options(self):
+            _bdist_wheel.finalize_options(self)
+            # Really, this is not pure python
+            self.root_is_pure = False
+except ImportError:
+    bdist_wheel = None
+
+setup(name='xapian',
+      version='${VERS}',
+      description='Xapian Bindings for Python3',
+      packages=['xapian'],
+      cmdclass={'bdist_wheel': bdist_wheel},
+      include_package_data=True,
+      zip_safe=False)
+EOF
+
+cat >$prefix/MANIFEST.in <<EOF
+include xapian/*
+EOF
+
+(
+    cd target
+    ${VE}/bin/python setup.py bdist_wheel
+    cp dist/*.whl ${WHL_DEST}
+)
+popd
+rm -rf "${WORKSPACE}"
+exittrap() { :; }

--- a/xapian_wheel_builder.sh
+++ b/xapian_wheel_builder.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 uname_sysname="$(uname -s)"
 case "${uname_sysname}" in
@@ -36,7 +36,7 @@ WHL_DEST=$(pwd)
 TMPDIR=$(mktemp -d -t "xapian-builder-XXXXXX") || die "Unable to mktemp"
 exittrap() { rm -rf "${TMPDIR}"; }
 echo "Building in ${TMPDIR}."
-pushd ${TMPDIR}
+cd "${TMPDIR}"
 
 echo "Preparing build virtualenv..."
 VE="${TMPDIR}/ve"
@@ -106,7 +106,7 @@ for file in $(find ${prefix}/xapian -name '*.so'); do
         Linux)
             # Binary patch rpath to be '$ORIGIN' as needed.
             rpath_offset=$(strings -t d ${file} | grep "${pprefix}/lib" | awk '{ printf $1; }')
-            printf "\$ORIGIN\x00" | dd of=${file} obs=1 seek=${rpath_offset} conv=notrunc 2>/dev/null
+            printf "\$ORIGIN\000" | dd of=${file} obs=1 seek=${rpath_offset} conv=notrunc 2>/dev/null
             # Verify
             readelf -d ${file} | grep RPATH | grep -q ORIGIN
             libxapian_name=$(ldd $file | grep libxapian | awk '{ printf $1; }')
@@ -158,6 +158,6 @@ EOF
     ${VE}/bin/python setup.py bdist_wheel
     cp dist/*.whl ${WHL_DEST}
 )
-popd
+cd "${WHL_DEST}"
 rm -rf "${TMPDIR}"
 exittrap() { :; }

--- a/xapian_wheel_builder.sh
+++ b/xapian_wheel_builder.sh
@@ -32,7 +32,7 @@ pushd ${WORKSPACE}
 echo "Preparing build virtualenv..."
 VE="${WORKSPACE}/ve"
 python3 -m venv ${VE}
-${VE}/bin/pip install --upgrade pip wheel setuptools
+${VE}/bin/python -m pip install --upgrade pip wheel setuptools
 
 # xapian before 1.4.12 had issues building with sphinx>=2
 SPHINX2_FIXED_VERSION=1.4.12

--- a/xapian_wheel_builder.sh
+++ b/xapian_wheel_builder.sh
@@ -6,6 +6,8 @@ case "${uname_sysname}" in
         ;;
     Darwin)
         ;;
+    FreeBSD)
+        ;;
     *)
         echo "Platform ${uname_sysname} is not supported"
         exit 1
@@ -108,6 +110,11 @@ echo "Building xapian python3 bindings..."
     # We want the sphinx we just put in a virtualenv because the xapian bindings insist on making their docs.
     # We use the python3 from that same virtualenv, because the xapian bindings don't use the shebang line of sphinx-build.
     # We override PYTHON3_LIB because if we don't then the bindings will be installed in the virutalenv, despite what we set prefix to.
+    case "${uname_sysname}" in
+	FreeBSD)
+	    sed -i '' -e 's|-lstdc++||' configure
+	    ;;
+    esac
     ./configure --prefix=$prefix --with-python3 XAPIAN_CONFIG=${XAPIAN_CONFIG} SPHINX_BUILD=${VE}/bin/sphinx-build PYTHON3=${VE}/bin/python3 PYTHON3_LIB=${prefix}
     make
     make install
@@ -116,7 +123,7 @@ echo "Building xapian python3 bindings..."
 echo "preparing xapian wheel..."
 for file in $(find ${prefix}/xapian -name '*.so'); do
     case "${uname_sysname}" in
-        Linux)
+        Linux|FreeBSD)
             # Binary patch rpath to be '$ORIGIN' as needed.
             rpath_offset=$(strings -t d ${file} | grep "${pprefix}/lib" | awk '{ printf $1; }')
             printf "\$ORIGIN\000" | dd of=${file} obs=1 seek=${rpath_offset} conv=notrunc 2>/dev/null

--- a/xapian_wheel_builder.sh
+++ b/xapian_wheel_builder.sh
@@ -11,9 +11,20 @@ case "${uname_sysname}" in
         exit 1
 esac
 
+PYTHON=$(which python3)
+set -- `getopt p: "$@"`
+for opt; do
+    case "$opt" in
+        -p)
+            PYTHON="$2"; shift 2 ;;
+        --)
+            shift ; break ;;
+    esac
+done
+
 VERSION=${1-${XAPIAN_VERSION}}
-if [ -z "$VERSION" ]; then
-    echo "usage: $0 version_number" 1>&2
+if [ -z "${VERSION}" ]; then
+    echo "usage: $0 [-p <path-to-python3>] version_number" 1>&2
     exit 1
 fi
 
@@ -31,7 +42,7 @@ pushd ${WORKSPACE}
 
 echo "Preparing build virtualenv..."
 VE="${WORKSPACE}/ve"
-python3 -m venv ${VE}
+${PYTHON} -m venv ${VE}
 ${VE}/bin/python -m pip install --upgrade pip wheel setuptools
 
 # xapian before 1.4.12 had issues building with sphinx>=2

--- a/xapian_wheel_builder.sh
+++ b/xapian_wheel_builder.sh
@@ -11,6 +11,12 @@ case "${uname_sysname}" in
         exit 1
 esac
 
+VERSION=${1-${XAPIAN_VERSION}}
+if [ -z "$VERSION" ]; then
+    echo "usage: $0 version_number" 1>&2
+    exit 1
+fi
+
 exittrap() { :; }
 for sig in 1 2 13 15; do trap "exit $(($sig + 128))" $sig; done
 trap 'exittrap' EXIT
@@ -29,13 +35,12 @@ python3 -m venv ${VE}
 ${VE}/bin/pip install --upgrade pip wheel setuptools
 ${VE}/bin/pip install "sphinx<2"
 
-VERS=${XAPIAN_VERSION-1.4.9}
-CORE="xapian-core-${VERS}"
-BINDINGS="xapian-bindings-${VERS}"
+CORE="xapian-core-${VERSION}"
+BINDINGS="xapian-bindings-${VERSION}"
 
 echo "Downloading source..."
-curl -O https://oligarchy.co.uk/xapian/${VERS}/${CORE}.tar.xz
-curl -O https://oligarchy.co.uk/xapian/${VERS}/${BINDINGS}.tar.xz
+curl -O https://oligarchy.co.uk/xapian/${VERSION}/${CORE}.tar.xz
+curl -O https://oligarchy.co.uk/xapian/${VERSION}/${BINDINGS}.tar.xz
 
 echo "Extracting source..."
 mkdir src
@@ -120,7 +125,7 @@ except ImportError:
     bdist_wheel = None
 
 setup(name='xapian',
-      version='${VERS}',
+      version='${VERSION}',
       description='Xapian Bindings for Python3',
       packages=['xapian'],
       cmdclass={'bdist_wheel': bdist_wheel},

--- a/xapian_wheel_builder.sh
+++ b/xapian_wheel_builder.sh
@@ -33,7 +33,14 @@ echo "Preparing build virtualenv..."
 VE="${WORKSPACE}/ve"
 python3 -m venv ${VE}
 ${VE}/bin/pip install --upgrade pip wheel setuptools
-${VE}/bin/pip install "sphinx<2"
+
+# xapian before 1.4.12 had issues building with sphinx>=2
+SPHINX2_FIXED_VERSION=1.4.12
+if [ $(printf "${VERSION}\n${SPHINX2_FIXED_VERSION}" | sort -V | head -n1) = "${SPHINX2_FIXED_VERSION}" ]; then
+    ${VE}/bin/pip install sphinx
+else
+    ${VE}/bin/pip install "sphinx<2"
+fi
 
 CORE="xapian-core-${VERSION}"
 BINDINGS="xapian-bindings-${VERSION}"

--- a/xapian_wheel_builder.sh
+++ b/xapian_wheel_builder.sh
@@ -35,6 +35,9 @@ trap 'exittrap' EXIT
 WHL_DEST=$(pwd)
 TMPDIR=$(mktemp -d -t "xapian-builder-XXXXXX") || die "Unable to mktemp"
 exittrap() { rm -rf "${TMPDIR}"; }
+
+set -e
+
 echo "Building in ${TMPDIR}."
 cd "${TMPDIR}"
 
@@ -108,7 +111,7 @@ for file in $(find ${prefix}/xapian -name '*.so'); do
             rpath_offset=$(strings -t d ${file} | grep "${pprefix}/lib" | awk '{ printf $1; }')
             printf "\$ORIGIN\000" | dd of=${file} obs=1 seek=${rpath_offset} conv=notrunc 2>/dev/null
             # Verify
-            readelf -d ${file} | grep RPATH | grep -q ORIGIN
+            readelf -d ${file} | grep RUNPATH | grep -q ORIGIN
             libxapian_name=$(ldd $file | grep libxapian | awk '{ printf $1; }')
             ;;
         Darwin)

--- a/xapian_wheel_builder.sh
+++ b/xapian_wheel_builder.sh
@@ -28,6 +28,11 @@ usage() {
     echo "usage: $0 [-p <path-to-python3>] version_number" 1>&2
 }
 
+version_at_least() {
+    test $(printf "${VERSION}\n${1}" | sort -V | head -n1) = "${1}"
+    return $?
+}
+
 VERSION=${1-${XAPIAN_VERSION}}
 if [ -z "${VERSION}" ]; then
     usage
@@ -59,8 +64,7 @@ ${PYTHON} -m venv ${VE}
 ${VE}/bin/python -m pip install --upgrade pip wheel setuptools
 
 # xapian before 1.4.12 had issues building with sphinx>=2
-SPHINX2_FIXED_VERSION=1.4.12
-if [ $(printf "${VERSION}\n${SPHINX2_FIXED_VERSION}" | sort -V | head -n1) = "${SPHINX2_FIXED_VERSION}" ]; then
+if version_at_least "1.4.12"; then
     ${VE}/bin/pip install sphinx
 else
     ${VE}/bin/pip install "sphinx<2"


### PR DESCRIPTION
This adds a script to build a wheel containing xapian python3 bindings along with a matching build of the xapian library.

I've been using this with xapian v1.4.9 for years now, and recently merged the linux and macOS versions into a single script.

This should not be used to create wheels for uploading to PyPI, but works well for building a deployable artefact for a known target.