### PR TITLE
install_xapian.sh - unpin sphinx for xapian >= 1.4.12

### DIFF
--- a/install_xapian.sh
+++ b/install_xapian.sh
@@ -39,7 +39,12 @@ fi
 
 # The bindings for Python require python-sphinx
 echo "Installing Python-Sphinx..."
-pip install "sphinx<2"
+SPHINX2_FIXED_VERSION=1.4.12
+if [ $(printf "${VERSION}\n${SPHINX2_FIXED_VERSION}" | sort -V | head -n1) = "${SPHINX2_FIXED_VERSION}" ]; then
+    pip install sphinx
+else
+    pip install "sphinx<2"
+fi
 
 echo "Installing Xapian-bindings..."
 cd $VIRTUAL_ENV/packages/${BINDINGS}


### PR DESCRIPTION
This uses the same logic in `xapian_wheel_builder.sh` in #201.