### PR TITLE
Better coverage handling

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,5 +7,16 @@ exclude_lines =
 
 [run]
 source =
-    haystack/backends/xapian_backend.py
+    haystack.backends.xapian_backend
     test_haystack/xapian_tests
+
+[paths]
+# Merge coverage data from running tests in a django-haystack
+# checkout with our own paths for coverage reporting.
+backend =
+    ./
+    */django-haystack/haystack/backends/
+
+tests =
+    tests/xapian_tests/
+    */django-haystack/test_haystack/xapian_tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,8 @@ jobs:
 
       - name: Coveralls
         run: |
-          cd django-haystack
+          coverage combine django-haystack/.coverage
+          coverage report
           coveralls --service=github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use `coverage combine` with some more configuration in `.coveragerc`
to merge our own paths with the paths we copy to when running coverage
and tests in the django-haystack checkout.

Also, print the simple coverage report in the Github Actions workflow
for good measure.

Fixes: #205