### PR TITLE
Drop code meant to support Xapian 1.2.x, 1.3.x.

### DIFF
--- a/install_xapian.sh
+++ b/install_xapian.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# first argument of the script is Xapian version (e.g. 1.2.19)
+# first argument of the script is Xapian version (e.g. 1.4.18)
 
 VERSION=$1
 
@@ -31,12 +31,6 @@ cd $VIRTUAL_ENV/packages/${CORE}
 
 PYTHON_FLAG=--with-python3
 
-if [ $VERSION = "1.3.3" ]; then
-    XAPIAN_CONFIG=$VIRTUAL_ENV/bin/xapian-config-1.3
-else
-    XAPIAN_CONFIG=
-fi
-
 # The bindings for Python require python-sphinx
 echo "Installing Python-Sphinx..."
 SPHINX2_FIXED_VERSION=1.4.12
@@ -48,7 +42,7 @@ fi
 
 echo "Installing Xapian-bindings..."
 cd $VIRTUAL_ENV/packages/${BINDINGS}
-./configure --prefix=$VIRTUAL_ENV $PYTHON_FLAG XAPIAN_CONFIG=$XAPIAN_CONFIG && make && make install
+./configure --prefix=$VIRTUAL_ENV $PYTHON_FLAG && make && make install
 
 # clean
 cd $VIRTUAL_ENV

--- a/tests/xapian_tests/tests/test_query.py
+++ b/tests/xapian_tests/tests/test_query.py
@@ -70,17 +70,12 @@ class XapianSearchQueryTestCase(HaystackBackendTestCase, TestCase):
         self.sq.add_filter(SQ(content=datetime.datetime(2009, 5, 8, 11, 28)))
         self.assertExpectedQuery(self.sq.build_query(),
                                  '((Z2009-05-08 OR 2009-05-08) OR'
-                                 ' (Z11:28:00 OR 11:28:00))',
-                                 xapian12string='(Z2009-05-08 OR 2009-05-08 OR'
-                                                ' Z11:28:00 OR 11:28:00)')
+                                 ' (Z11:28:00 OR 11:28:00))')
 
     def test_datetime_not(self):
         self.sq.add_filter(~SQ(content=datetime.datetime(2009, 5, 8, 11, 28)))
         self.assertExpectedQuery(self.sq.build_query(),
-                                 '(<alldocuments> AND_NOT ((Z2009-05-08 OR 2009-05-08) OR (Z11:28:00 OR 11:28:00)))',
-                                 xapian12string='(<alldocuments> AND_NOT '
-                                                '(Z2009-05-08 OR 2009-05-08 OR'
-                                                ' Z11:28:00 OR 11:28:00))')
+                                 '(<alldocuments> AND_NOT ((Z2009-05-08 OR 2009-05-08) OR (Z11:28:00 OR 11:28:00)))')
 
     def test_float(self):
         self.sq.add_filter(SQ(content=25.52))
@@ -103,8 +98,7 @@ class XapianSearchQueryTestCase(HaystackBackendTestCase, TestCase):
         self.sq.add_filter(SQ(content='hello') | SQ(content='world'))
         self.assertExpectedQuery(
             self.sq.build_query(),
-            '((Zhello OR hello) OR (Zworld OR world))',
-            xapian12string='(Zhello OR hello OR Zworld OR world)')
+            '((Zhello OR hello) OR (Zworld OR world))')
 
     def test_multiple_words_or_not(self):
         self.sq.add_filter(~SQ(content='hello') | ~SQ(content='world'))
@@ -118,9 +112,7 @@ class XapianSearchQueryTestCase(HaystackBackendTestCase, TestCase):
         self.assertExpectedQuery(
             self.sq.build_query(),
             '(((Zwhi OR why) OR (Zhello OR hello)) AND '
-            '(<alldocuments> AND_NOT (Zworld OR world)))',
-            xapian12string='((Zwhi OR why OR Zhello OR hello) AND'
-                           ' (<alldocuments> AND_NOT (Zworld OR world)))',)
+            '(<alldocuments> AND_NOT (Zworld OR world)))')
 
     def test_multiple_word_field_exact(self):
         self.sq.add_filter(SQ(foo='hello'))
@@ -139,15 +131,13 @@ class XapianSearchQueryTestCase(HaystackBackendTestCase, TestCase):
     def test_or(self):
         self.sq.add_filter(SQ(content='hello world'))
         self.assertExpectedQuery(
-            self.sq.build_query(), '((Zhello OR hello) OR (Zworld OR world))',
-            xapian12string='(Zhello OR hello OR Zworld OR world)')
+            self.sq.build_query(), '((Zhello OR hello) OR (Zworld OR world))')
 
     def test_not_or(self):
         self.sq.add_filter(~SQ(content='hello world'))
         self.assertExpectedQuery(
             self.sq.build_query(),
-            '(<alldocuments> AND_NOT ((Zhello OR hello) OR (Zworld OR world)))',
-            xapian12string='(<alldocuments> AND_NOT (Zhello OR hello OR Zworld OR world))')
+            '(<alldocuments> AND_NOT ((Zhello OR hello) OR (Zworld OR world)))')
 
     def test_boost(self):
         self.sq.add_filter(SQ(content='hello'))

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -285,11 +285,7 @@ class XapianSearchBackend(BaseSearchBackend):
             term_generator = xapian.TermGenerator()
             term_generator.set_database(database)
             term_generator.set_stemmer(xapian.Stem(self.language))
-            try:
-                term_generator.set_stemming_strategy(self.stemming_strategy)
-            except AttributeError:  
-                # Versions before Xapian 1.2.11 do not support stemming strategies for TermGenerator
-                pass
+            term_generator.set_stemming_strategy(self.stemming_strategy)
             if self.include_spelling is True:
                 term_generator.set_flags(xapian.TermGenerator.FLAG_SPELLING)
 

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -27,13 +27,6 @@ except ImportError:
                             "Please refer to the documentation.")
 
 
-class NotSupportedError(Exception):
-    """
-    When the installed version of Xapian doesn't support something and we have
-    the old implementation.
-    """
-    pass
-
 # this maps the different reserved fields to prefixes used to
 # create the database:
 # id str: unique document id.
@@ -644,10 +637,7 @@ class XapianSearchBackend(BaseSearchBackend):
         enquire.set_query(query)
 
         if sort_by:
-            try:
-                _xapian_sort(enquire, sort_by, self.column)
-            except NotSupportedError:
-                _old_xapian_sort(enquire, sort_by, self.column)
+            _xapian_sort(enquire, sort_by, self.column)
 
         results = []
         facets_dict = {
@@ -1647,25 +1637,8 @@ def _from_xapian_value(value, field_type):
         return value
 
 
-def _old_xapian_sort(enquire, sort_by, column):
-    sorter = xapian.MultiValueSorter()
-
-    for sort_field in sort_by:
-        if sort_field.startswith('-'):
-            reverse = True
-            sort_field = sort_field[1:]  # Strip the '-'
-        else:
-            reverse = False  # Reverse is inverted in Xapian -- http://trac.xapian.org/ticket/311
-        sorter.add(column[sort_field], reverse)
-
-    enquire.set_sort_by_key_then_relevance(sorter, True)
-
-
 def _xapian_sort(enquire, sort_by, column):
-    try:
-        sorter = xapian.MultiValueKeyMaker()
-    except AttributeError:
-        raise NotSupportedError
+    sorter = xapian.MultiValueKeyMaker()
 
     for sort_field in sort_by:
         if sort_field.startswith('-'):


### PR DESCRIPTION
xapian-haystack now lists xapian 1.4.x as the minimum supported version, so we don't need to carry around code to support 1.2.x anymore.