### PR TITLE
Github Actions - pin coverage to 5.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Install Django and other Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install django~=${{ matrix.django-version }} coveralls xapian*.whl
+          pip install django~=${{ matrix.django-version }} coverage~=5.5 coveralls xapian*.whl
 
       - name: Checkout django-haystack
         uses: actions/checkout@v2


### PR DESCRIPTION
Coverage 6.0+ does not get along with django-haystack, importing haystack before django is configured.