### PR TITLE
coveragerc - switch from source to include

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,9 +6,9 @@ exclude_lines =
     except xapian.DatabaseModifiedError
 
 [run]
-source =
-    haystack.backends.xapian_backend
-    test_haystack/xapian_tests
+include =
+    haystack/backends/xapian_backend.py
+    test_haystack/xapian_tests/*
 
 [paths]
 # Merge coverage data from running tests in a django-haystack


### PR DESCRIPTION
Rather than pin coverage (#212), rework `.coveragerc` to use `include` instead of `source` since that avoids the early import issue.