### PR TITLE
Expand the test matrix to include python 3.10 / django 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.9]
-        xapian-version: [1.4.18]
+        python-version: ['3.6', '3.9', '3.10']
+        xapian-version: ['1.4.18']
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -41,9 +41,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.9]
-        django-version: [2.2, 3.1, 3.2]
-        xapian-version: [1.4.18]
+        python-version: ['3.6', '3.9']
+        django-version: ['2.2', '3.1', '3.2']
+        xapian-version: ['1.4.18']
+        include:
+          # Django added python 3.10 support in 3.2.9
+          - python-version: '3.10'
+            django-version: '3.2'
+            xapian-version: '1.4.18'
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
Django 3.2.9 added support for python 3.10, but older versions still
list the maximum supported version as 3.9.

https://docs.djangoproject.com/en/3.2/faq/install/

This adds python 3.10 / django 3.2 to the test matrix, and builds a
xapian wheel for python 3.10.

Version numbers changed to strings for consistency. Python 3.10 needs
to be quoted because it would otherwise be interpreted as 3.1.