### PR TITLE
Revert "coveragerc - switch from source to include"

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,9 +6,9 @@ exclude_lines =
     except xapian.DatabaseModifiedError
 
 [run]
-include =
-    haystack/backends/xapian_backend.py
-    test_haystack/xapian_tests/*
+source =
+    haystack.backends.xapian_backend
+    test_haystack/xapian_tests
 
 [paths]
 # Merge coverage data from running tests in a django-haystack


### PR DESCRIPTION
This reverts commit c6248769d4b0f352fc45c7a9250c360c90448656.

Coverage upstream has fixed the issue this was working around.