### PR TITLE
Fix multiple workers from breaking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,13 +42,15 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.6', '3.9']
-        django-version: ['2.2', '3.1', '3.2']
+        django-version: ['2.2', '3.1', '3.2', '4.0']
         xapian-version: ['1.4.18']
+        filelock-version: ['3.4.2']
         include:
           # Django added python 3.10 support in 3.2.9
           - python-version: '3.10'
-            django-version: '3.2'
+            django-version: '4.0'
             xapian-version: '1.4.18'
+            filelock-version: '3.4.2'
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -70,7 +72,7 @@ jobs:
       - name: Install Django and other Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install django~=${{ matrix.django-version }} coveralls xapian*.whl
+          pip install django~=${{ matrix.django-version }} filelock~=${{ matrix.filelock-version }} coveralls xapian*.whl
 
       - name: Checkout django-haystack
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.9', '3.10']
-        xapian-version: ['1.4.18']
+        python-version: ["3.6", "3.9", "3.10"]
+        xapian-version: ["1.4.18"]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -41,16 +41,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.9']
-        django-version: ['2.2', '3.1', '3.2', '4.0']
-        xapian-version: ['1.4.18']
-        filelock-version: ['3.4.2']
+        python-version: ["3.6", "3.9"]
+        django-version: ["2.2", "3.1", "3.2", "4.0"]
+        xapian-version: ["1.4.18"]
+        filelock-version: ["3.4.2"]
         include:
           # Django added python 3.10 support in 3.2.9
-          - python-version: '3.10'
-            django-version: '4.0'
-            xapian-version: '1.4.18'
-            filelock-version: '3.4.2'
+          - python-version: "3.10"
+            django-version: "4.0"
+            xapian-version: "1.4.18"
+            filelock-version: "3.4.2"
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -77,7 +77,7 @@ jobs:
       - name: Checkout django-haystack
         uses: actions/checkout@v2
         with:
-          repository: 'django-haystack/django-haystack'
+          repository: "django-haystack/django-haystack"
           path: django-haystack
 
       - name: Copy some test files to django-haystack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.9", "3.10"]
-        django-version: ["2.2", "3.1", "3.2", "4.0"]
+        python-version: ["3.6", "3.9"]
+        django-version: ["2.2", "3.1", "3.2"]
         xapian-version: ["1.4.18"]
-        filelock-version: ["3.4.1", "3.4.2"]
+        filelock-version: ["3.4.1"]
         include:
           # Django added python 3.10 support in 3.2.9
           - python-version: "3.10"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.9"]
+        python-version: ["3.6", "3.9", "3.10"]
         django-version: ["2.2", "3.1", "3.2", "4.0"]
         xapian-version: ["1.4.18"]
-        filelock-version: ["3.4.2"]
+        filelock-version: ["3.4.1", "3.4.2"]
         include:
           # Django added python 3.10 support in 3.2.9
           - python-version: "3.10"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django>=2.2
 Django-Haystack>=3.0
-filelock~=3.4.2
+filelock~=3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django>=2.2
 Django-Haystack>=3.0
-filelock==3.4.2
+filelock~=3.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django>=2.2
 Django-Haystack>=3.0
+filelock==3.4.2

--- a/tests/xapian_tests/tests/test_backend.py
+++ b/tests/xapian_tests/tests/test_backend.py
@@ -72,6 +72,8 @@ class HaystackBackendTestCase:
         self.ui.build(indexes=[self.index])
         self.backend = connections['default'].get_backend()
         connections['default']._index = self.ui
+        os.mkdir(self.backend.path)
+
 
     def tearDown(self):
         self.backend.clear()

--- a/tests/xapian_tests/tests/test_backend.py
+++ b/tests/xapian_tests/tests/test_backend.py
@@ -1,6 +1,5 @@
 from decimal import Decimal
 import datetime
-import errno
 import inspect
 import sys
 import xapian
@@ -73,12 +72,6 @@ class HaystackBackendTestCase:
         self.ui.build(indexes=[self.index])
         self.backend = connections['default'].get_backend()
         connections['default']._index = self.ui
-        try:
-            os.mkdir(self.backend.path)
-        except OSError as exc:
-            if exc.errno != errno.EEXIST:
-                raise
-
 
     def tearDown(self):
         self.backend.clear()

--- a/tests/xapian_tests/tests/test_backend.py
+++ b/tests/xapian_tests/tests/test_backend.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 import datetime
+import errno
 import inspect
 import sys
 import xapian
@@ -72,7 +73,11 @@ class HaystackBackendTestCase:
         self.ui.build(indexes=[self.index])
         self.backend = connections['default'].get_backend()
         connections['default']._index = self.ui
-        os.mkdir(self.backend.path)
+        try:
+            os.mkdir(self.backend.path)
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                raise
 
 
     def tearDown(self):

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -1,5 +1,6 @@
 import datetime
 import pickle
+from pathlib import Path
 import os
 import re
 import shutil
@@ -78,13 +79,12 @@ TERMPOS_DISTANCE = 100
 
 def filelocked(func):
     """Decorator to wrap a method in a filelock."""
+
     def wrapper(self, *args, **kwargs):
-        with open(self.lockfile, "w"):
-            # recreate the lockfile just in case.
-            # useful for tests.
-            os.utime(self.lockfile, None)
+        self.lockfile.touch()
         with self.filelock:
             func(self, *args, **kwargs)
+
     return wrapper
 
 class InvalidIndexError(HaystackError):
@@ -202,7 +202,7 @@ class XapianSearchBackend(BaseSearchBackend):
             except FileExistsError:
                 pass
 
-        self.lockfile = os.path.join(self.path,  "lockfile")
+        self.lockfile = Path(self.path) / "lockfile"
         self.filelock = FileLock(self.lockfile)
 
         self.flags = connection_options.get('FLAGS', DEFAULT_XAPIAN_FLAGS)

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -190,7 +190,11 @@ class XapianSearchBackend(BaseSearchBackend):
             except FileExistsError:
                 pass
 
-        self.filelock = FileLock(os.path.join(self.path,  "lockfile"))
+        # create the lockfile before using it.
+        lockfile_path = os.path.join(self.path,  "lockfile")
+        with open(lockfile_path, "a"):
+            os.utime(lockfile_path, None)
+        self.filelock = FileLock(lockfile_path)
 
         self.flags = connection_options.get('FLAGS', DEFAULT_XAPIAN_FLAGS)
         self.language = getattr(settings, 'HAYSTACK_XAPIAN_LANGUAGE', 'english')

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -78,14 +78,18 @@ TERMPOS_DISTANCE = 100
 
 
 def filelocked(func):
-    """Decorator to wrap a method in a filelock."""
+    """Decorator to wrap a XapianSearchBackend method in a filelock."""
 
     def wrapper(self, *args, **kwargs):
+         
+        # Ensure the lockfile exists
         try:
-            self.lockfile.parent.mkdir()
+            self.lockfile.parent.mkdir(parents=True)
         except FileExistsError:
             pass
         self.lockfile.touch()
+
+        # run the function inside a lock
         with self.filelock:
             func(self, *args, **kwargs)
 

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -81,6 +81,10 @@ def filelocked(func):
     """Decorator to wrap a method in a filelock."""
 
     def wrapper(self, *args, **kwargs):
+        try:
+            self.lockfile.parent.mkdir()
+        except FileExistsError:
+            pass
         self.lockfile.touch()
         with self.filelock:
             func(self, *args, **kwargs)


### PR DESCRIPTION
# Problem
If xapian-haystack is used today with more than one worker it breaks with `xapian.DatabaseLockError`

# Solution
This solution was cribbed from @karolyi in his issue report: https://github.com/notanumber/xapian-haystack/issues/174
It implements a lockfile around the update() and remove methods.

# Decisions
It is compatible with python2 and doesn't use pathlib.

It makes the opinionated decision to place a lockfile in the xapian-index directory. There are various other places where its good to put lockfiles on different systems, but as this lockfile will not be accessed very often, placing in the regular filesystem on disk seems fine and less platform specific code is required to place the lockfile somewhere special.

The renaming of the original functions to private versions was done to reduce the size of this PR. Other solutions are possible.


# Workarounds
This PR can be used as inspiration for an easy workaround for this issue. Subclass XapianSearchBackend and BaseEngine with these changes. and use that in your Haystack settings. Example here: https://github.com/ajslater/codex/blob/develop/codex/search_engine.py