### PR TITLE
Management Command Database Locking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,12 +71,12 @@ jobs:
       - name: Install Django and other Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install django~=${{ matrix.django-version }} filelock~=${{ matrix.filelock-version }} coveralls xapian*.whl
+          pip install django~=${{ matrix.django-version }} coveralls xapian*.whl
 
       - name: Checkout django-haystack
         uses: actions/checkout@v2
         with:
-          repository: "django-haystack/django-haystack"
+          repository: 'django-haystack/django-haystack'
           path: django-haystack
 
       - name: Copy some test files to django-haystack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
           # Django dropped python 3.7 support in 4.0
           - python-version: '3.7'
             django-version: '4.0'
+
     steps:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install Django and other Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install django~=${{ matrix.django-version }} coveralls xapian*.whl
+          pip install django~=${{ matrix.django-version }} filelock~=${{ matrix.filelock-version }} coveralls xapian*.whl
 
       - name: Checkout django-haystack
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         xapian-version: ['1.4.18']
+
     steps:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         xapian-version: ['1.4.18']
+        filelock-version: ["3.4.2"]
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -44,16 +45,14 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         django-version: ['2.2', '3.2', '4.0']
         xapian-version: ['1.4.18']
+        filelock-version: ['3.4.2']
         exclude:
           # Django added python 3.10 support in 3.2.9
           - python-version: '3.10'
             django-version: '2.2'
-            xapian-version: '1.4.18'
           # Django dropped python 3.7 support in 4.0
           - python-version: '3.7'
             django-version: '4.0'
-            xapian-version: '1.4.18'
-
     steps:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -74,12 +73,12 @@ jobs:
       - name: Install Django and other Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install django~=${{ matrix.django-version }} coveralls xapian*.whl
+          pip install django~=${{ matrix.django-version }} filelock~=${{ matrix.filelock-version }} coveralls xapian*.whl
 
       - name: Checkout django-haystack
         uses: actions/checkout@v2
         with:
-          repository: 'django-haystack/django-haystack'
+          repository: "django-haystack/django-haystack"
           path: django-haystack
 
       - name: Copy some test files to django-haystack

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,6 @@ jobs:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         xapian-version: ['1.4.18']
-        filelock-version: ["3.4.2"]
-
     steps:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,8 @@ Unreleased
 ----------
 
 - Dropped support for Python 3.6.
+- Fixed DatabaseLocked errors when running management commands with
+  multiple workers.
 
 v3.0.1 (2021-11-12)
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ The backend has the following optional settings:
   See `here <http://xapian.org/docs/apidoc/html/classXapian_1_1QueryParser.html#ac7dc3b55b6083bd3ff98fc8b2726c8fd>`__ for
   more information about the different strategies.
 
-- ``USE_LOCKFILE``: Use a lockfile to prevent database locking errors when running managment commands with multiple workers.
+- ``HAYSTACK_XAPIAN_USE_LOCKFILE``: Use a lockfile to prevent database locking errors when running managment commands with multiple workers.
   Defaults to `True`.
 
 Testing

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ The backend has the following optional settings:
   See `here <http://xapian.org/docs/apidoc/html/classXapian_1_1QueryParser.html#ac7dc3b55b6083bd3ff98fc8b2726c8fd>`__ for
   more information about the different strategies.
 
-- ``HAYSTACK_XAPIAN_USE_LOCKFILE``: Use a lockfile to prevent database locking errors when running managment commands with multiple workers.
+- ``HAYSTACK_XAPIAN_USE_LOCKFILE``: Use a lockfile to prevent database locking errors when running management commands with multiple workers.
   Defaults to `True`.
 
 Testing

--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,8 @@ The backend has the following optional settings:
   See `here <http://xapian.org/docs/apidoc/html/classXapian_1_1QueryParser.html#ac7dc3b55b6083bd3ff98fc8b2726c8fd>`__ for
   more information about the different strategies.
 
+- ``USE_LOCKFILE``: Use a lockfile to prevent database locking errors when running managment commands with multiple workers.
+  Defaults to `True`.
 
 Testing
 -------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django>=2.2
 Django-Haystack>=3.0
+filelock~=3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Django>=2.2
 Django-Haystack>=3.0
-filelock~=3.4.1
+filelock>=3.4

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,6 @@ setup(
     install_requires=[
         'django>=2.2',
         'django-haystack>=2.8.0',
+        'filelock~=3.4.1',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setup(
     install_requires=[
         'django>=2.2',
         'django-haystack>=2.8.0',
-        'filelock~=3.4.1',
+        'filelock>=3.4',
     ]
 )

--- a/tests/xapian_tests/tests/test_backend.py
+++ b/tests/xapian_tests/tests/test_backend.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 import datetime
 import inspect
+from pathlib import Path
 import sys
 import xapian
 import subprocess

--- a/tests/xapian_tests/tests/test_backend.py
+++ b/tests/xapian_tests/tests/test_backend.py
@@ -1,7 +1,6 @@
 from decimal import Decimal
 import datetime
 import inspect
-from pathlib import Path
 import sys
 import xapian
 import subprocess

--- a/tests/xapian_tests/tests/test_management_commands.py
+++ b/tests/xapian_tests/tests/test_management_commands.py
@@ -89,5 +89,5 @@ class ManagementCommandTestCase(HaystackBackendTestCase, TestCase):
         call_command("clear_index", interactive=False, verbosity=0)
         self.verify_indexed_document_count(0)
 
-        call_command("update_index", verbosity=2, workers=2, batchsize=5)
+        call_command("update_index", verbosity=2, workers=5, batchsize=10)
         self.verify_indexed_documents()

--- a/tests/xapian_tests/tests/test_management_commands.py
+++ b/tests/xapian_tests/tests/test_management_commands.py
@@ -1,3 +1,4 @@
+import sys
 from io import StringIO
 from unittest import TestCase
 
@@ -90,16 +91,16 @@ class ManagementCommandTestCase(HaystackBackendTestCase, TestCase):
         call_command("clear_index", interactive=False, verbosity=0)
         self.verify_indexed_document_count(0)
 
-        out = StringIO()
-        err = StringIO()
+        old_stderr = sys.stderr
+        sys.stderr = StringIO()
         call_command(
             "update_index",
             verbosity=2,
             workers=10,
-            batchsize=10,
-            stdout=out,
-            stderr=err,
+            batchsize=2,
         )
-        self.assertNotIn("xapian.DatabaseLockError", err.getvalue())
-        self.assertNotIn("xapian.DatabaseLockError", out.getvalue())
+        err = sys.stderr.getvalue()
+        sys.stderr = old_stderr
+        print(err)
+        self.assertNotIn("xapian.DatabaseLockError", err)
         self.verify_indexed_documents()

--- a/tests/xapian_tests/tests/test_management_commands.py
+++ b/tests/xapian_tests/tests/test_management_commands.py
@@ -1,3 +1,4 @@
+from io import StringIO
 from unittest import TestCase
 
 from django.core.management import call_command
@@ -89,5 +90,16 @@ class ManagementCommandTestCase(HaystackBackendTestCase, TestCase):
         call_command("clear_index", interactive=False, verbosity=0)
         self.verify_indexed_document_count(0)
 
-        call_command("update_index", verbosity=2, workers=5, batchsize=5)
+        out = StringIO()
+        err = StringIO()
+        call_command(
+            "update_index",
+            verbosity=2,
+            workers=10,
+            batchsize=10,
+            stdout=out,
+            stderr=err,
+        )
+        self.assertNotIn("xapian.DatabaseLockError", err.getvalue())
+        self.assertNotIn("xapian.DatabaseLockError", out.getvalue())
         self.verify_indexed_documents()

--- a/tests/xapian_tests/tests/test_management_commands.py
+++ b/tests/xapian_tests/tests/test_management_commands.py
@@ -84,3 +84,10 @@ class ManagementCommandTestCase(HaystackBackendTestCase, TestCase):
         # … but remove does:
         call_command("update_index", remove=True, verbosity=0)
         self.verify_indexed_document_count(self.NUM_BLOG_ENTRIES - 3)
+
+    def test_multiprocessing(self):
+        call_command("clear_index", interactive=False, verbosity=0)
+        self.verify_indexed_document_count(0)
+
+        call_command("update_index", verbosity=2, workers=2, batchsize=5)
+        self.verify_indexed_documents()

--- a/tests/xapian_tests/tests/test_management_commands.py
+++ b/tests/xapian_tests/tests/test_management_commands.py
@@ -26,8 +26,6 @@ class ManagementCommandTestCase(HaystackBackendTestCase, TestCase):
             self.sample_objs.append(entry)
             entry.save()
 
-        self.backend.update(self.index, BlogEntry.objects.all())
-
     def verify_indexed_document_count(self, expected):
         count = self.backend.document_count()
         self.assertEqual(count, expected)
@@ -88,7 +86,6 @@ class ManagementCommandTestCase(HaystackBackendTestCase, TestCase):
         self.verify_indexed_document_count(self.NUM_BLOG_ENTRIES - 3)
 
     def test_multiprocessing(self):
-        call_command("clear_index", interactive=False, verbosity=0)
         self.verify_indexed_document_count(0)
 
         old_stderr = sys.stderr

--- a/tests/xapian_tests/tests/test_management_commands.py
+++ b/tests/xapian_tests/tests/test_management_commands.py
@@ -24,6 +24,8 @@ class ManagementCommandTestCase(HaystackBackendTestCase, TestCase):
             self.sample_objs.append(entry)
             entry.save()
 
+        self.backend.update(self.index, BlogEntry.objects.all())
+
     def verify_indexed_document_count(self, expected):
         count = self.backend.document_count()
         self.assertEqual(count, expected)

--- a/tests/xapian_tests/tests/test_management_commands.py
+++ b/tests/xapian_tests/tests/test_management_commands.py
@@ -89,5 +89,5 @@ class ManagementCommandTestCase(HaystackBackendTestCase, TestCase):
         call_command("clear_index", interactive=False, verbosity=0)
         self.verify_indexed_document_count(0)
 
-        call_command("update_index", verbosity=2, workers=5, batchsize=10)
+        call_command("update_index", verbosity=2, workers=5, batchsize=5)
         self.verify_indexed_documents()

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -85,8 +85,9 @@ def filelocked(func):
         if self.path == MEMORY_DB_NAME or not self.use_lockfile:
             func(self, *args, **kwargs)
         else:
-            Path(self.path).mkdir(parents=True, exist_ok=True)
-            Path(self.filelock.lock_file).touch()
+            lockfile = Path(self.filelock.lock_file)
+            lockfile.parent.mkdir(parents=True, exist_ok=True)
+            lockfile.touch()
             with self.filelock:
                 func(self, *args, **kwargs)
 

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -85,10 +85,7 @@ def filelocked(func):
         if self.path == MEMORY_DB_NAME:
             func(self, *args, **kwargs)
         else:
-            try:
-                Path(self.path).mkdir(parents=True)
-            except FileExistsError:
-                pass
+            Path(self.path).mkdir(parents=True, exist_ok=True)
             Path(self.filelock.lock_file).touch()
             with self.filelock:
                 func(self, *args, **kwargs)

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -188,7 +188,9 @@ class XapianSearchBackend(BaseSearchBackend):
 
         Also sets the stemming language to be used to `language`.
         """
-        self.use_lockfile = bool(connection_options.get('HAYSTACK_XAPIAN_USE_LOCKFILE', True))
+        self.use_lockfile = bool(
+            getattr(settings, 'HAYSTACK_XAPIAN_USE_LOCKFILE', True)
+        )
         super().__init__(connection_alias, **connection_options)
 
         if not 'PATH' in connection_options:

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -188,6 +188,7 @@ class XapianSearchBackend(BaseSearchBackend):
 
         Also sets the stemming language to be used to `language`.
         """
+        self.use_lockfile = bool(connection_options.get('HAYSTACK_XAPIAN_USE_LOCKFILE', True))
         super().__init__(connection_alias, **connection_options)
 
         if not 'PATH' in connection_options:
@@ -195,7 +196,6 @@ class XapianSearchBackend(BaseSearchBackend):
                                        % connection_alias)
 
         self.path = connection_options.get('PATH')
-        self.use_lockfile = connection_options.get('USE_LOCKFILE', True)
 
         if self.path != MEMORY_DB_NAME:
             try:


### PR DESCRIPTION
## Problem
If xapian-haystack management commands are used today with more than one worker it breaks with xapian.DatabaseLockError

## Solution
This solution was cribbed from [@karolyi](https://github.com/karolyi) in his issue report: [#174](https://github.com/notanumber/xapian-haystack/issues/174) . 
I implement a lockfile decorator around the update() and remove() methods.

## Decisions

It paces the lockfile in the xapian-index directory, which should not affect performance.

## Tests

This PR includes a new `test_management_commands.py` test suite that runs the management commands. This test suite fails if the lockfile isn't implemented as you can see in this branch: https://github.com/ajslater/xapian-haystack/actions/runs/1798091039

## Workarounds

This PR can be used as inspiration for an easy workaround for this issue. Subclass XapianSearchBackend and BaseEngine with these changes. and use that in your Haystack settings. Example here: https://github.com/ajslater/codex/blob/develop/codex/search_engine.py