### PR TITLE
GitHub Actions: rework test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         xapian-version: ['1.4.18']
 
     steps:
@@ -41,13 +41,17 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.9']
-        django-version: ['2.2', '3.1', '3.2']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        django-version: ['2.2', '3.2', '4.0']
         xapian-version: ['1.4.18']
-        include:
+        exclude:
           # Django added python 3.10 support in 3.2.9
           - python-version: '3.10'
-            django-version: '3.2'
+            django-version: '2.2'
+            xapian-version: '1.4.18'
+          # Django dropped python 3.7 support in 4.0
+          - python-version: '3.7'
+            django-version: '4.0'
             xapian-version: '1.4.18'
 
     steps:


### PR DESCRIPTION
Drop Django 3.1 (EoL)
Add Django 4.0
Add Python 3.8 (Minimum version for Django 4.0)
Add Python 3.10 to the general matrix, not just for Djagno 3.2

Exclude Django 2.2 from Python 3.10 testing.
Exclude Django 4.0 from Python 3.7 testing.

Django 2.2 will EoL in a little over a month, at which point we can
trim the matrix down again by dropping it and Python 3.9 if we want
to.