### PR TITLE
GitHub Actions: rework test matrix (drop Django 2.2, py3.9)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.10']
         xapian-version: ['1.4.19']
 
     steps:
@@ -41,14 +41,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
-        django-version: ['2.2', '3.2', '4.0']
+        python-version: ['3.7', '3.8', '3.10']
+        django-version: ['3.2', '4.0']
         xapian-version: ['1.4.19']
         filelock-version: ['3.4.2']
         exclude:
-          # Django added python 3.10 support in 3.2.9
-          - python-version: '3.10'
-            django-version: '2.2'
           # Django dropped python 3.7 support in 4.0
           - python-version: '3.7'
             django-version: '4.0'


### PR DESCRIPTION
- Drop Django 2.2 (EoL)
- Drop Python 3.9 build, since all supported Django versions support
  3.10 now.

```
3.7  3.8  3.9  3.10
|----Django 3.2---|
     |-Django 4.0-|
```