### PR TITLE
Automatically detect all cores when the --use-all-cores flag is passed

### DIFF
--- a/install_xapian.sh
+++ b/install_xapian.sh
@@ -8,6 +8,11 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
+JFLAG=1
+if [ "$2" = "--use-all-cores" ]; then
+  JFLAG=$(($(getconf _NPROCESSORS_ONLN) + 1))
+fi
+
 # prepare
 mkdir -p $VIRTUAL_ENV/packages && cd $VIRTUAL_ENV/packages
 
@@ -27,7 +32,7 @@ tar xf ${BINDINGS}.tar.xz
 # install
 echo "Installing Xapian-core..."
 cd $VIRTUAL_ENV/packages/${CORE}
-./configure --prefix=$VIRTUAL_ENV && make && make install
+./configure --prefix=$VIRTUAL_ENV && make -j$JFLAG && make install
 
 PYTHON_FLAG=--with-python3
 

--- a/xapian_wheel_builder.sh
+++ b/xapian_wheel_builder.sh
@@ -110,11 +110,16 @@ case "${uname_sysname}" in
     ;;
 esac
 
+JFLAG=1
+if [ "$2" = "--use-all-cores" ]; then
+  JFLAG=$(($(getconf _NPROCESSORS_ONLN) + 1))
+fi
+
 echo "Building xapian core..."
 (
     cd "src/${CORE}"
     ./configure --prefix="${pprefix}"
-    make
+    make -j$JFLAG
     make install
 )
 


### PR DESCRIPTION
As title says - I decided not to pass the custom flags for building bindings, because I know sometimes multithread compilation sometimes can break stuff - if I will get free time I will test it with it too.