### PR TITLE
Add DJANGO_CT, DJANGO_ID, ID to be used with '__exact' internally.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ xapian-haystack Changelog
 Unreleased
 ----------
 
+- Add DJANGO_CT, DJANGO_ID, ID to be used with '__exact' internally.
 - Dropped support for Python 3.6.
 - Fixed DatabaseLocked errors when running management commands with
   multiple workers.

--- a/tests/xapian_tests/tests/test_query.py
+++ b/tests/xapian_tests/tests/test_query.py
@@ -236,6 +236,13 @@ class XapianSearchQueryTestCase(HaystackBackendTestCase, TestCase):
         self.sq.add_filter(SQ(django_ct='time'))
         self.assertExpectedQuery(self.sq.build_query(), 'CONTENTTYPEtime')
 
+    def test_unphrased_id(self):
+        'An internal ID should NOT be phrased so one can exclude IDs.'
+        self.sq.add_filter(SQ(id__in=['testing123', 'testing456']))
+        expected = '(Qtesting123 OR Qtesting456)'
+        self.assertExpectedQuery(
+            query=self.sq.build_query(), string_or_list=expected)
+
 
 class SearchQueryTestCase(HaystackBackendTestCase, TestCase):
     """

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -42,6 +42,8 @@ TERM_PREFIXES = {
     'field': 'X'
 }
 
+_EXACT_SEARCHFIELDS = frozenset((DJANGO_CT, DJANGO_ID, ID))
+
 MEMORY_DB_NAME = ':memory:'
 
 DEFAULT_XAPIAN_FLAGS = (
@@ -1437,7 +1439,7 @@ class XapianSearchQuery(BaseSearchQuery):
 
         Assumes term is not a list.
         """
-        if field_type == 'text' and field_name not in (DJANGO_CT,):
+        if field_type == 'text' and field_name not in _EXACT_SEARCHFIELDS:
             term = '^ %s $' % term
             query = self._phrase_query(term.split(), field_name, field_type)
         else:


### PR DESCRIPTION
Hey,

somewhere around 8568e49b8f350ea3ce1358fad014c40b84f087b6 an exclusion has been added to `django_ct` with an `__exact` search. I need to add the other django internal fields excluded from text searches as well. 

In my use case I `.exclude(` some IDs for which I search for with the internal `id` field, that is a text field and did get escaped as a phrase because of that. My code uses `SearchQuerySet.exclude(id__list=['id_1', 'id_2']` which in the current state will not work.

These commits are about that, and also about preparing a new release. Please do a release ASAP, as I need these changes and can't use the official packages until this gets merged. I'm using my on gitea mirror for now, but would like to get back to using the official packages.