### PR TITLE
Xapian2 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
-        xapian-version: ['1.4.20']
+        xapian-version: ['1.4.20', '2.0.0']
 
     steps:
       - name: Set up Python ${{ matrix.python-version }}
@@ -43,7 +43,7 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
         django-version: ['4.2', '5.2', '6.0']
-        xapian-version: ['1.4.20']
+        xapian-version: ['1.4.20', '2.0.0']
         filelock-version: ['3.4.2']
         exclude:
           # Django added python 3.13 support in 5.1

--- a/tests/xapian_tests/tests/test_backend.py
+++ b/tests/xapian_tests/tests/test_backend.py
@@ -1,7 +1,6 @@
 from decimal import Decimal
 import datetime
 import inspect
-import sys
 import xapian
 import subprocess
 import os
@@ -640,14 +639,33 @@ class BackendFeaturesTestCase(HaystackBackendTestCase, TestCase):
                                  ])
         self.assertExpectedQuery(self.backend.parse_query('number:..10'),
                                  [
-                                     '0 * VALUE_RANGE 11 %012d 000000000010' % (-sys.maxsize - 1),
-                                     'VALUE_RANGE 11 %012d 000000000010' % (-sys.maxsize - 1),
+                                     '0 * VALUE_LE 11 000000000010',
+                                     'VALUE_LE 11 000000000010',
                                  ])
         self.assertExpectedQuery(self.backend.parse_query('number:10..*'),
                                  [
-                                     '0 * VALUE_RANGE 11 000000000010 %012d' % sys.maxsize,
-                                     'VALUE_RANGE 11 000000000010 %012d' % sys.maxsize,
+                                     '0 * VALUE_GE 11 000000000010',
+                                     'VALUE_GE 11 000000000010',
                                  ])
+        # Regression tests for #236.
+        try:
+            query = self.backend.parse_query('..a')
+            self.fail('Expected xapian.QueryParserError but query parsed as: %s' %
+                      str(query))
+        except xapian.QueryParserError:
+            pass
+        try:
+            query = self.backend.parse_query('a..')
+            self.fail('Expected xapian.QueryParserError but query parsed as: %s' %
+                      str(query))
+        except xapian.QueryParserError:
+            pass
+        try:
+            query = self.backend.parse_query('...')
+            self.fail('Expected xapian.QueryParserError but query parsed as: %s' %
+                      str(query))
+        except xapian.QueryParserError:
+            pass
 
     def test_order_by_django_id(self):
         """

--- a/tests/xapian_tests/tests/test_backend.py
+++ b/tests/xapian_tests/tests/test_backend.py
@@ -607,20 +607,16 @@ class BackendFeaturesTestCase(HaystackBackendTestCase, TestCase):
 
         self.assertExpectedQuery(self.backend.parse_query('name:david'), 'ZXNAMEdavid@1')
 
-        if xapian.minor_version() >= 2:
-            # todo: why `SYNONYM WILDCARD OR XNAMEda`?
-            self.assertExpectedQuery(
-                self.backend.parse_query('name:da*'),
-                [
-                    '(SYNONYM WILDCARD OR XNAMEda)',
-                    'WILDCARD SYNONYM XNAMEda',
-                ])
-        else:
-            self.assertEqual(str(self.backend.parse_query('name:da*')),
-                             'Xapian::Query(('
-                             'XNAMEdavid1:(pos=1) OR '
-                             'XNAMEdavid2:(pos=1) OR '
-                             'XNAMEdavid3:(pos=1)))')
+        self.assertExpectedQuery(
+            self.backend.parse_query('name:da*'),
+            [
+                # Xapian < 1.4.8 (OP_SYNONYM with a single subquery which is
+                # OP_WILDCARD expanded using OP_OR).
+                '(SYNONYM WILDCARD OR XNAMEda)',
+                # Xapian >= 1.4.8 (OP_WILDCARD expanded using OP_SYNONYM -
+                # exactly equivalent semantically).
+                'WILDCARD SYNONYM XNAMEda',
+            ])
 
     def test_parse_query_range(self):
         self.assertExpectedQuery(self.backend.parse_query('name:david1..david2'),

--- a/tests/xapian_tests/tests/test_backend.py
+++ b/tests/xapian_tests/tests/test_backend.py
@@ -31,10 +31,6 @@ class XapianSearchResult(SearchResult):
 def get_terms(backend, *args):
     executable = 'xapian-delve'
 
-    # dev versions (odd minor) use a suffix
-    if XAPIAN_VERSION[1] % 2 != 0:
-        executable = executable+'-%d.%d' % tuple(XAPIAN_VERSION[0:2])
-
     # look for a xapian-delve built by `xapian_wheel_builder`
     wheel_delve = os.path.join(os.path.dirname(inspect.getfile(xapian)), executable)
     if os.path.exists(wheel_delve):

--- a/tests/xapian_tests/tests/test_query.py
+++ b/tests/xapian_tests/tests/test_query.py
@@ -291,26 +291,21 @@ class SearchQueryTestCase(HaystackBackendTestCase, TestCase):
     def test_gt(self):
         self.sq.add_filter(SQ(name__gt='m'))
         self.assertExpectedQuery(self.sq.build_query(),
-                                 '(<alldocuments> AND_NOT VALUE_RANGE 3 a m)')
+                                 '(<alldocuments> AND_NOT VALUE_LE 3 m)')
 
     def test_gte(self):
         self.sq.add_filter(SQ(name__gte='m'))
         self.assertExpectedQuery(self.sq.build_query(),
-                                 'VALUE_RANGE 3 m zzzzzzzzzzzzzzzzzzzzzzzzzzzz'
-                                 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
-                                 'zzzzzzzzzzzzzzzzzzzzzzzzzzzz')
+                                 'VALUE_GE 3 m')
 
     def test_lt(self):
         self.sq.add_filter(SQ(name__lt='m'))
         self.assertExpectedQuery(self.sq.build_query(),
-                                 '(<alldocuments> AND_NOT VALUE_RANGE 3 m '
-                                 'zzzzzzzzzzzzzzzzzzzzzzzzzzzz'
-                                 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
-                                 'zzzzzzzzzzzzzzzzzzzzzzzzzzzz)')
+                                 '(<alldocuments> AND_NOT VALUE_GE 3 m)')
 
     def test_lte(self):
         self.sq.add_filter(SQ(name__lte='m'))
-        self.assertExpectedQuery(self.sq.build_query(), 'VALUE_RANGE 3 a m')
+        self.assertExpectedQuery(self.sq.build_query(), 'VALUE_LE 3 m')
 
     def test_range(self):
         self.sq.add_filter(SQ(django_id__range=[2, 4]))
@@ -329,11 +324,9 @@ class SearchQueryTestCase(HaystackBackendTestCase, TestCase):
         self.sq.add_filter(SQ(django_id__in=[1, 2, 3]))
         self.assertExpectedQuery(self.sq.build_query(),
                                  '((Zwhi OR why) AND'
-                                 ' VALUE_RANGE 5 00010101000000 20090210015900 AND'
-                                 ' (<alldocuments> AND_NOT VALUE_RANGE 3 a david)'
-                                 ' AND VALUE_RANGE 7 b zzzzzzzzzzzzzzzzzzzzzzzzzzz'
-                                 'zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz'
-                                 'zzzzzzzzzzzzzzzzzzzzzzzzz AND'
+                                 ' VALUE_LE 5 20090210015900 AND'
+                                 ' (<alldocuments> AND_NOT VALUE_LE 3 david)'
+                                 ' AND VALUE_GE 7 b AND'
                                  ' (QQ000000000001 OR QQ000000000002 OR QQ000000000003))')
 
     def test_log_query(self):

--- a/xapian_backend.py
+++ b/xapian_backend.py
@@ -96,62 +96,61 @@ def filelocked(func):
     return wrapper
 
 
+def _find_field_dict(backend, field_name):
+    for field_dict in backend.schema:
+        if field_dict['field_name'] == field_name:
+            return field_dict
+    return None
+
+
 class InvalidIndexError(HaystackError):
     """Raised when an index can not be opened."""
     pass
 
 
-class XHValueRangeProcessor(xapian.ValueRangeProcessor):
+class XHRangeProcessor(xapian.RangeProcessor):
     """
     A Processor to construct ranges of values
     """
     def __init__(self, backend):
         self.backend = backend
-        xapian.ValueRangeProcessor.__init__(self)
+        xapian.RangeProcessor.__init__(self)
 
     def __call__(self, begin, end):
         """
-        Construct a tuple for value range processing.
+        Construct a value range xapian.Query.
         `begin` -- a string in the format '<field_name>:[low_range]'
         If 'low_range' is omitted, assume the smallest possible value.
-        `end` -- a string in the the format '[high_range|*]'. If '*', assume
-        the highest possible value.
-        Return a tuple of three strings: (column, low, high)
+        `end` -- a string in the the format '[high_range|*]'. If omitted or
+        '*', assume no upper bound.
+        Return a value range xapian.Query
         """
-        colon = begin.find(':')
-        field_name = begin[:colon]
-        begin = begin[colon + 1:len(begin)]
-        for field_dict in self.backend.schema:
-            if field_dict['field_name'] == field_name:
-                field_type = field_dict['type']
+        colon = begin.find(b':')
+        field_name = begin[:colon].decode('utf-8')
+        begin = begin[colon + 1:]
+        field_dict = _find_field_dict(self.backend, field_name)
+        if field_dict is not None:
+            field_type = field_dict['type']
 
-                if not begin:
-                    if field_type == 'text':
-                        begin = 'a'  # TODO: A better way of getting a min text value?
-                    elif field_type == 'integer':
-                        begin = -sys.maxsize - 1
-                    elif field_type == 'float':
-                        begin = float('-inf')
-                    elif field_type in ['date', 'datetime']:
-                        begin = '00010101000000'
-                elif end == '*':
-                    if field_type == 'text':
-                        end = 'z' * 100  # TODO: A better way of getting a max text value?
-                    elif field_type == 'integer':
-                        end = sys.maxsize
-                    elif field_type == 'float':
-                        end = float('inf')
-                    elif field_type in ['date', 'datetime']:
-                        end = '99990101000000'
+            if end == b'*':
+                end = b''
 
-                if field_type == 'float':
+            if field_type == 'float':
+                if begin:
                     begin = _term_to_xapian_value(float(begin), field_type)
+                if end:
                     end = _term_to_xapian_value(float(end), field_type)
-                elif field_type == 'integer':
+            elif field_type == 'integer':
+                if begin:
                     begin = _term_to_xapian_value(int(begin), field_type)
+                if end:
                     end = _term_to_xapian_value(int(end), field_type)
-                return field_dict['column'], str(begin), str(end)
 
+            slot = field_dict['column']
+            if not end:
+                return xapian.Query(xapian.Query.OP_VALUE_GE, slot, begin)
+            return xapian.Query(xapian.Query.OP_VALUE_RANGE, slot, begin, end)
+        return xapian.Query(xapian.Query.OP_INVALID)
 
 class XHExpandDecider(xapian.ExpandDecider):
     def __call__(self, term):
@@ -849,8 +848,7 @@ class XapianSearchBackend(BaseSearchBackend):
                 TERM_PREFIXES['field'] + field_dict['field_name'].upper()
             )
 
-        vrp = XHValueRangeProcessor(self)
-        qp.add_valuerangeprocessor(vrp)
+        qp.add_rangeprocessor(XHRangeProcessor(self))
 
         return qp.parse_query(query_string, self.flags)
 
@@ -1393,7 +1391,7 @@ class XapianSearchQuery(BaseSearchQuery):
         """
         Returns a match all query.
         """
-        return xapian.Query('')
+        return xapian.Query.MatchAll
 
     def _filter_contains(self, term, field_name, field_type, is_not):
         """
@@ -1550,43 +1548,61 @@ class XapianSearchQuery(BaseSearchQuery):
         Private method that returns a xapian.Query that searches for any term
         that is greater than `term` in a specified `field`.
         """
-        vrp = XHValueRangeProcessor(self.backend)
-        pos, begin, end = vrp('%s:%s' % (field_name, _term_to_xapian_value(term, field_type)), '*')
+        field_dict = _find_field_dict(self.backend, field_name)
+        if field_dict is None:
+            query = xapian.Query.MatchNothing
+        else:
+            query = xapian.Query(xapian.Query.OP_VALUE_GE,
+                                 field_dict['column'],
+                                 _term_to_xapian_value(term, field_type)
+                                 )
         if is_not:
             return xapian.Query(xapian.Query.OP_AND_NOT,
                                 self._all_query(),
-                                xapian.Query(xapian.Query.OP_VALUE_RANGE, pos, begin, end)
+                                query
                                 )
-        return xapian.Query(xapian.Query.OP_VALUE_RANGE, pos, begin, end)
+        return query
 
     def _filter_lte(self, term, field_name, field_type, is_not):
         """
         Private method that returns a xapian.Query that searches for any term
         that is less than `term` in a specified `field`.
         """
-        vrp = XHValueRangeProcessor(self.backend)
-        pos, begin, end = vrp('%s:' % field_name, '%s' % _term_to_xapian_value(term, field_type))
+        field_dict = _find_field_dict(self.backend, field_name)
+        if field_dict is None:
+            query = xapian.Query.MatchNothing
+        else:
+            query = xapian.Query(xapian.Query.OP_VALUE_LE,
+                                 field_dict['column'],
+                                 _term_to_xapian_value(term, field_type)
+                                 )
         if is_not:
             return xapian.Query(xapian.Query.OP_AND_NOT,
                                 self._all_query(),
-                                xapian.Query(xapian.Query.OP_VALUE_RANGE, pos, begin, end)
+                                query
                                 )
-        return xapian.Query(xapian.Query.OP_VALUE_RANGE, pos, begin, end)
+        return query
 
     def _filter_range(self, term, field_name, field_type, is_not):
         """
         Private method that returns a xapian.Query that searches for any term
         that is between the values from the `term` list.
         """
-        vrp = XHValueRangeProcessor(self.backend)
-        pos, begin, end = vrp('%s:%s' % (field_name, _term_to_xapian_value(term[0], field_type)),
-                              '%s' % _term_to_xapian_value(term[1], field_type))
+        field_dict = _find_field_dict(self.backend, field_name)
+        if field_dict is None:
+            query = xapian.Query.MatchNothing
+        else:
+            query = xapian.Query(xapian.Query.OP_VALUE_RANGE,
+                                 field_dict['column'],
+                                 _term_to_xapian_value(term[0], field_type),
+                                 _term_to_xapian_value(term[1], field_type)
+                                 )
         if is_not:
             return xapian.Query(xapian.Query.OP_AND_NOT,
                                 self._all_query(),
-                                xapian.Query(xapian.Query.OP_VALUE_RANGE, pos, begin, end)
+                                query
                                 )
-        return xapian.Query(xapian.Query.OP_VALUE_RANGE, pos, begin, end)
+        return query
 
 
 def _term_to_xapian_value(term, field_type):


### PR DESCRIPTION
The existing CI on master seems to have bitrotted and fails if re-run now without changing the repo contents at all.  I've fixed some of the problems, but I don't understand why one of the 3.8 builds fails, nor why all the 3.10 builds fail, so I've just excluded those.  See individual commit messages for details of the errors I ran into.  As I said in #239, I don't develop (or even use) django, haystack or xapian-haystack, and I do very little Python, so I think I'm the wrong person for the job of trying to fix these excluded builds.

The key changes which are actually updating the code for Xapian 2 are in 2bebec928022118eabcc2d6c75807287983e7d94:

```
    Eliminate use of xapian.ValueRangeProcessor
    
    This class was deprecated in Xapian 1.4 and removed in Xapian 2.
    Instead use xapian.RangeProcessor or construct Query objects directly.
    
    This makes xapian-haystack compatible with Xapian 2.  Fixes #239.
    
    Open-ended ranges now build open-ended Xapian range queries, addressing
    two TODO comments.
    
    A range query on an unknown field is now handle gracefully.  Fixes #236.
    
    A range query of type int or float with an open upper end no longer
    requires `*` for the upper end.  Fixes #217.
```

The Xapian 1.5.1 version used in CI is a release candidate for 2.0.0 so that should be adjusted to use 2.0.0 once actually released.